### PR TITLE
feat: touch gesture improvements

### DIFF
--- a/src/__tests__/board.spec.tsx
+++ b/src/__tests__/board.spec.tsx
@@ -409,6 +409,74 @@ describe('interaction', () => {
     expect(squareE7?.querySelector('[data-selected]')).toBeTruthy();
   });
 
+  it('treats 5px movement as drag for mouse pointer', () => {
+    const onMove = vi.fn(() => true);
+    const { container } = render(<Board movable onMove={onMove} />);
+    const grid = container.querySelector('[data-board-grid]') as HTMLElement;
+
+    // e2 center: x=270, y=390. Move 5px (above 4px mouse threshold)
+    fireEvent.pointerDown(grid, {
+      clientX: 270,
+      clientY: 390,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    fireEvent.pointerMove(grid, {
+      clientX: 275,
+      clientY: 390,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    // Ghost piece should appear (drag started)
+    expect(container.querySelector('[data-ghost]')).toBeTruthy();
+  });
+
+  it('treats 5px movement as click for touch pointer', () => {
+    const { container } = render(<Board movable />);
+    const grid = container.querySelector('[data-board-grid]') as HTMLElement;
+
+    // e2 center: x=270, y=390. Move 5px (below 10px touch threshold)
+    fireEvent.pointerDown(grid, {
+      clientX: 270,
+      clientY: 390,
+      pointerId: 1,
+      pointerType: 'touch',
+    });
+    fireEvent.pointerMove(grid, {
+      clientX: 275,
+      clientY: 390,
+      pointerId: 1,
+      pointerType: 'touch',
+    });
+
+    // No ghost — still counted as a tap, not a drag
+    expect(container.querySelector('[data-ghost]')).toBeFalsy();
+  });
+
+  it('treats 11px movement as drag for touch pointer', () => {
+    const onMove = vi.fn(() => true);
+    const { container } = render(<Board movable onMove={onMove} />);
+    const grid = container.querySelector('[data-board-grid]') as HTMLElement;
+
+    // e2 center: x=270, y=390. Move 11px (above 10px touch threshold)
+    fireEvent.pointerDown(grid, {
+      clientX: 270,
+      clientY: 390,
+      pointerId: 1,
+      pointerType: 'touch',
+    });
+    fireEvent.pointerMove(grid, {
+      clientX: 281,
+      clientY: 390,
+      pointerId: 1,
+      pointerType: 'touch',
+    });
+
+    // Ghost piece should appear (drag started)
+    expect(container.querySelector('[data-ghost]')).toBeTruthy();
+  });
+
   it('does not re-select a wrong-color piece during click-to-move', () => {
     const { container } = render(<Board movable turn="white" />);
     const grid = container.querySelector('[data-board-grid]') as HTMLElement;

--- a/src/hooks/use-drag.ts
+++ b/src/hooks/use-drag.ts
@@ -45,6 +45,7 @@ interface UseDragResult {
 }
 
 interface PointerDownInfo {
+  pointerType: string;
   square: Square;
   x: number;
   y: number;
@@ -95,7 +96,8 @@ function getSquareFromPointer(
   return coordsToSquare(col, row, orientation);
 }
 
-const DRAG_THRESHOLD = 4;
+const DRAG_THRESHOLD_MOUSE = 4;
+const DRAG_THRESHOLD_TOUCH = 10;
 
 function useDrag({
   boardRef,
@@ -191,6 +193,7 @@ function useDrag({
       // Always track the pointer-down square so onPointerUp can handle
       // click-to-move targets (even on empty squares).
       pointerDownReference.current = {
+        pointerType: event.pointerType,
         square,
         x: event.clientX,
         y: event.clientY,
@@ -219,12 +222,14 @@ function useDrag({
         return;
       }
 
-      const { x, y } = pointerDownReference.current;
+      const { pointerType, x, y } = pointerDownReference.current;
       const dx = event.clientX - x;
       const dy = event.clientY - y;
       const distance = Math.hypot(dx, dy);
+      const threshold =
+        pointerType === 'touch' ? DRAG_THRESHOLD_TOUCH : DRAG_THRESHOLD_MOUSE;
 
-      if (distance >= DRAG_THRESHOLD) {
+      if (distance >= threshold) {
         setDragState((previous) => ({
           ...previous,
           floating: { x: event.clientX, y: event.clientY },
@@ -242,6 +247,7 @@ function useDrag({
       }
 
       const {
+        pointerType,
         square: downSquare,
         x: downX,
         y: downY,
@@ -251,7 +257,9 @@ function useDrag({
       const dx = event.clientX - downX;
       const dy = event.clientY - downY;
       const distance = Math.hypot(dx, dy);
-      const isClick = distance < DRAG_THRESHOLD;
+      const threshold =
+        pointerType === 'touch' ? DRAG_THRESHOLD_TOUCH : DRAG_THRESHOLD_MOUSE;
+      const isClick = distance < threshold;
 
       // Clear drag state
       setDragState({ floating: undefined, from: undefined, isDragging: false });


### PR DESCRIPTION
## Summary

- uses `event.pointerType` to apply a larger drag threshold for touch input (10px) vs mouse (4px) — prevents accidental drags from finger jitter while keeping mouse precision
- stores `pointerType` from the pointer-down event and uses it consistently in both move and up handlers

the other items from the issue were already handled:
- `touchAction: 'none'` was already set on both grid branches
- tap-to-move (click-to-move) already works on touch via the existing pointer events API

closes #4