### PR TITLE
chore: release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2.1.0] - 2026-04-16
+
+### Added
+
+- right-click drawable annotations — `drawable` prop, circle and arrow drawing
+  via `useDrawing` hook and `AnnotationOverlay` component
+- SVG arrow overlay — `arrows` prop with semantic `kind` types (`move`,
+  `alternative`, `danger`, `capture`)
+- touch-aware drag threshold (10px for touch, 4px for mouse)
+- `movable` prop to control piece interaction independently from `drawable`
+
+### Fixed
+
+- drag restricted to left-click only (right-click no longer initiates drag)
+
 ## [2.0.0] - 2026-04-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echecs/react-board",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "license": "MIT",
   "description": "React chessboard component with drag & drop, animation, and theming. Bundled cburnett piece set, zero external dependencies.",


### PR DESCRIPTION
## Summary

- bumps version to `2.1.0`
- adds changelog entry for all changes since `v2.0.0`

once merged, tag `v2.1.0` on main to trigger CI publish.