### PR TITLE
fix: add docs script for CI storybook deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist/
+/docs/api/
 /node_modules/
 /storybook-static/
 .playwright-mcp/

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   "scripts": {
     "build": "tsdown",
     "storybook": "storybook dev -p 6006",
+    "docs": "storybook build -o docs/api",
     "storybook:build": "storybook build",
     "format": "pnpm run format:ci --write",
     "format:ci": "prettier -l \"**/*.+(css|js|json|jsx|md|mjs|mts|ts|tsx|yml|yaml)\"",


### PR DESCRIPTION
## Summary

- the shared `docs.yml` workflow runs `pnpm run docs` but no such script existed — CI was failing with `ERR_PNPM_NO_SCRIPT`
- adds a `docs` script that builds storybook into `docs/api` (where the workflow expects it)
- adds `docs/api/` to `.gitignore`