### PR TITLE
chore: release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.1.1] - 2026-04-16
+
+### Fixed
+
+- animation offset stuck when parent re-renders during RAF window — removed
+  `cancelAnimationFrame` cleanup from `useAnimation` effect since the
+  offset-clearing callback is idempotent (#14)
+- added `docs` script for CI storybook deployment (#13)
+- added missing `Annotations`, `ArrowKind`, `Circle` types to README (#16)
+
 ## [2.1.0] - 2026-04-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echecs/react-board",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "license": "MIT",
   "description": "React chessboard component with drag & drop, animation, and theming. Bundled cburnett piece set, zero external dependencies.",


### PR DESCRIPTION
## Summary

- bumps version to 2.1.1
- adds changelog entry for animation fix (#14), docs script (#13), and README types update (#16)

after merge, tag `v2.1.1` needs to be created on main to trigger CI publish.