### PR TITLE
fix: remove inline width: 100% to allow square board in height-constrained layouts

### DIFF
--- a/src/board.tsx
+++ b/src/board.tsx
@@ -145,7 +145,6 @@ function Board({
   const rootStyle: React.CSSProperties = {
     aspectRatio: '1 / 1',
     position: 'relative',
-    width: '100%',
   };
 
   const gridStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary

- removes the inline `width: 100%` from the board root container, fixing #18
- `aspect-ratio: 1/1` on a block-level `div` already fills available width via normal flow — the explicit width was redundant in block contexts and actively broken in flex row layouts where the parent is wider than tall
- the root style is now just `{ aspectRatio: '1/1', position: 'relative' }`

closes #18