### PR TITLE
chore: release v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.1.2] - 2026-04-19
+
+### Fixed
+
+- inline `width: 100%` on the board root preventing square rendering in
+  height-constrained layouts (flex rows, grid columns) — the board now uses only
+  `aspect-ratio: 1/1` and lets the parent control sizing (#18)
+
 ## [2.1.1] - 2026-04-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echecs/react-board",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "type": "module",
   "license": "MIT",
   "description": "React chessboard component with drag & drop, animation, and theming. Bundled cburnett piece set, zero external dependencies.",


### PR DESCRIPTION
## Summary

- bumps version to `2.1.2`
- updates CHANGELOG with the fix from #19 — removes inline `width: 100%` from the board root to allow square rendering in height-constrained layouts