### PR TITLE
feat: enable storybook autodocs with prop descriptions

### DIFF
--- a/src/__stories__/board.stories.tsx
+++ b/src/__stories__/board.stories.tsx
@@ -38,6 +38,7 @@ const meta: Meta<BoardProperties> = {
       </div>
     ),
   ],
+  tags: ['autodocs'],
   title: 'Board',
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,22 +15,37 @@ interface Arrow {
 }
 
 interface BoardProperties {
+  /** Enable CSS transition animations for piece movement. Defaults to `true`. */
   animate?: boolean;
+  /** Arrows to render on the board (e.g. for analysis or engine lines). */
   arrows?: Arrow[];
+  /** Overlay elements rendered on top of the board (e.g. promotion dialogs). */
   children?: React.ReactNode;
+  /** Show rank and file coordinates around the board. Defaults to `true`. */
   coordinates?: boolean;
+  /** Allow right-click drawing of arrows and circles. */
   drawable?: boolean;
+  /** Squares to highlight (e.g. last move origin and destination). */
   highlight?: Square[];
   /** @deprecated Use `movable` instead. */
   interactive?: boolean;
+  /** Map of legal moves per square, used to show move hints on selection. */
   legalMoves?: Map<Square, Square[]>;
+  /** Allow pieces to be moved via drag or click. */
   movable?: boolean;
+  /** Called when user-drawn annotations change. */
   onAnnotationChange?: (annotations: Annotations) => void;
+  /** Called when a piece is moved. Return `true` to accept the move. */
   onMove?: (move: MoveEvent) => boolean;
+  /** Called when a square is clicked. */
   onSquareClick?: (square: Square) => void;
+  /** Board orientation. `'white'` shows rank 1 at the bottom. */
   orientation?: 'black' | 'white';
+  /** Custom SVG piece set, keyed by piece code (e.g. `wK`, `bQ`). */
   pieces?: PieceSet;
+  /** Board position as a FEN string or a `Map<Square, Piece>`. */
   position?: Map<Square, Piece> | string;
+  /** Restrict which side can move. `undefined` allows both. */
   turn?: 'black' | 'white';
 }
 


### PR DESCRIPTION
## Summary

- adds `tags: ['autodocs']` to story meta — generates a docs page with interactive prop table
- adds JSDoc comments to all `BoardProperties` fields so autodocs renders descriptions