### PR TITLE
fix: switch dependabot ecosystem from pnpm to npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: pnpm
+  - package-ecosystem: npm
     directory: '/'
     schedule:
       interval: daily


### PR DESCRIPTION
workaround for dependabot not supporting pnpm v10 — npm ecosystem reads package.json and updates pnpm-lock.yaml correctly