### PR TITLE
refactor: inline Piece and Square types, drop @echecs/position dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,6 @@
   "peerDependencies": {
     "react": ">=18"
   },
-  "dependencies": {
-    "@echecs/position": "^1.0.0"
-  },
   "devDependencies": {
     "@echecs/game": "^2.0.0",
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@echecs/position':
-        specifier: ^1.0.0
-        version: 1.0.2
     devDependencies:
       '@echecs/game':
         specifier: ^2.0.0
@@ -246,10 +242,6 @@ packages:
 
   '@echecs/game@2.0.2':
     resolution: {integrity: sha512-/OduSZPw5xaM3vaLL81wj/T4r06QfZ1nBGsPfuHlg8QZ2fz2tNJLSHCy5tzHP7eq6ZU/I4rDzPRQwGFfILZA/g==}
-    engines: {node: '>=20'}
-
-  '@echecs/position@1.0.2':
-    resolution: {integrity: sha512-8H5onNRSudqyblCr0q2+TNxrQHkWwWYqcaC737GFjjHre4YsPx0v4P9RYME6EIso4VuQC1cK2KwoBtKLEVhcIQ==}
     engines: {node: '>=20'}
 
   '@echecs/position@3.0.5':
@@ -2666,8 +2658,6 @@ snapshots:
   '@echecs/game@2.0.2':
     dependencies:
       '@echecs/position': 3.0.5
-
-  '@echecs/position@1.0.2': {}
 
   '@echecs/position@3.0.5':
     dependencies:

--- a/src/__stories__/board.stories.tsx
+++ b/src/__stories__/board.stories.tsx
@@ -14,10 +14,11 @@ import type {
   Arrow,
   BoardProps as BoardProperties,
   MoveEvent,
+  Piece,
   PieceKey,
   PieceSet,
+  Square,
 } from '../types.js';
-import type { Piece, Square } from '@echecs/position';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<BoardProperties> = {

--- a/src/__tests__/board.spec.tsx
+++ b/src/__tests__/board.spec.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import Board from '../board.js';
 
-import type { Square } from '@echecs/position';
+import type { Square } from '../types.js';
 
 const STARTING_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 

--- a/src/__tests__/use-animation.spec.ts
+++ b/src/__tests__/use-animation.spec.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAnimation } from '../hooks/use-animation.js';
 
-import type { Piece, Square } from '@echecs/position';
+import type { Piece, Square } from '../types.js';
 
 function makePosition(entries: [Square, Piece][]): Map<Square, Piece> {
   return new Map(entries);

--- a/src/__tests__/utilities.spec.ts
+++ b/src/__tests__/utilities.spec.ts
@@ -8,7 +8,7 @@ import {
   squareCoords,
 } from '../utilities.js';
 
-import type { Piece, Square } from '@echecs/position';
+import type { Piece, Square } from '../types.js';
 
 describe('SQUARES', () => {
   it('has 64 entries', () => {

--- a/src/fen.ts
+++ b/src/fen.ts
@@ -1,4 +1,4 @@
-import type { Piece, Square } from '@echecs/position';
+import type { Piece, Square } from './types.js';
 
 const FILE_CHARS = 'abcdefgh';
 

--- a/src/hooks/use-animation.ts
+++ b/src/hooks/use-animation.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { diffPositions, squareCoords } from '../utilities.js';
 
-import type { Piece, Square } from '@echecs/position';
+import type { Piece, Square } from '../types.js';
 import type React from 'react';
 
 interface AnimationOffset {

--- a/src/hooks/use-drag.ts
+++ b/src/hooks/use-drag.ts
@@ -1,10 +1,9 @@
 import { useCallback, useRef, useState } from 'react';
 
-import type { MoveEvent } from '../types.js';
-import type { Piece, Square } from '@echecs/position';
-import type React from 'react';
-
 import { getSquareFromPointer } from '../utilities.js';
+
+import type { MoveEvent, Piece, Square } from '../types.js';
+import type React from 'react';
 
 interface DragState {
   floating: { x: number; y: number } | undefined;

--- a/src/hooks/use-drawing.ts
+++ b/src/hooks/use-drawing.ts
@@ -1,10 +1,15 @@
 import { useCallback, useRef, useState } from 'react';
 
-import type { Square } from '@echecs/position';
-import type { Annotations, Arrow, ArrowKind, Circle } from '../types.js';
-import type React from 'react';
-
 import { getSquareFromPointer } from '../utilities.js';
+
+import type {
+  Annotations,
+  Arrow,
+  ArrowKind,
+  Circle,
+  Square,
+} from '../types.js';
+import type React from 'react';
 
 interface UseDrawingOptions {
   boardRef: React.RefObject<HTMLDivElement | null>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,26 @@
-import type { Piece, Square } from '@echecs/position';
 import type React from 'react';
 
 type ArrowKind = 'alternative' | 'capture' | 'danger' | 'move';
+
+type Color = 'b' | 'w';
+
+type File = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h';
+
+type PieceType = 'b' | 'k' | 'n' | 'p' | 'q' | 'r';
+
+type Rank = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8';
+
+/**
+ * A board square, e.g. `'e4'`. Combination of {@link File} and {@link Rank}.
+ *
+ * @preventExpand
+ */
+type Square = `${File}${Rank}`;
+
+interface Piece {
+  color: Color;
+  type: PieceType;
+}
 
 interface Annotations {
   arrows: Arrow[];
@@ -84,6 +103,8 @@ export type {
   BoardProperties as BoardProps,
   Circle,
   MoveEvent,
+  Piece,
   PieceKey,
   PieceSet,
+  Square,
 };

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,4 +1,4 @@
-import type { Piece, Square } from '@echecs/position';
+import type { Piece, Square } from './types.js';
 
 const FILES = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const;
 const RANKS = ['8', '7', '6', '5', '4', '3', '2', '1'] as const;


### PR DESCRIPTION
## Summary

- duplicates `Piece`, `Square`, and supporting types (`Color`, `File`, `PieceType`, `Rank`) locally in `src/types.ts` — same pattern used in sibling packages
- adds `@preventExpand` to `Square` so typedoc doesn't expand the 64-literal union
- removes `@echecs/position` from `dependencies` entirely — it was only used for types
- makes PR #28 (dependabot bump to 3.0.5) obsolete