### PR TITLE
release: @echecs/react-board@2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2.1.3] - 2026-04-26
+
+### Changed
+
+- inlined `Piece` and `Square` types locally, removing `@echecs/position` as a
+  runtime dependency — lighter install, no functional change (#39)
+
+### Fixed
+
+- storybook autodocs page not rendering — added missing `@storybook/addon-docs`
+  dependency (#40)
+- deduplicated rendering logic in Board component (#22)
+
 ## [2.1.2] - 2026-04-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echecs/react-board",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "type": "module",
   "license": "MIT",
   "description": "React chessboard component with drag & drop, animation, and theming. Bundled cburnett piece set, zero external dependencies.",


### PR DESCRIPTION
## Summary

- inlined `Piece` and `Square` types, dropped `@echecs/position` runtime dependency
- fixed storybook autodocs by adding `@storybook/addon-docs`
- deduplicated Board rendering logic
- devDep bumps