### PR TITLE
feat!: align piece types with @echecs/position

### DIFF
--- a/docs/superpowers/plans/2026-05-01-align-piece-types.md
+++ b/docs/superpowers/plans/2026-05-01-align-piece-types.md
@@ -1,10 +1,17 @@
 # Align Piece Types with @echecs/position — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace locally defined `Color`, `PieceType`, `Piece`, `File`, `Rank`, `Square` types with imports from `@echecs/position` so consumers can pass position data directly without conversion.
+**Goal:** Replace locally defined `Color`, `PieceType`, `Piece`, `File`, `Rank`,
+`Square` types with imports from `@echecs/position` so consumers can pass
+position data directly without conversion.
 
-**Architecture:** Import domain types from `@echecs/position` (peer dep). Keep `PieceKey`/`PieceSet` as-is for rendering. Add internal mapping from `Piece` → `PieceKey`. Update FEN parser values, promotion dialog, and tests.
+**Architecture:** Import domain types from `@echecs/position` (peer dep). Keep
+`PieceKey`/`PieceSet` as-is for rendering. Add internal mapping from `Piece` →
+`PieceKey`. Update FEN parser values, promotion dialog, and tests.
 
 **Tech Stack:** TypeScript, React, vitest, @echecs/position@^3
 
@@ -13,6 +20,7 @@
 ### Task 1: Add `@echecs/position` as peer dependency
 
 **Files:**
+
 - Modify: `package.json:53-55`
 
 - [ ] **Step 1: Add `@echecs/position` to peerDependencies**
@@ -28,8 +36,8 @@ In `package.json`, add `@echecs/position` to the existing `peerDependencies`:
 
 - [ ] **Step 2: Verify install**
 
-Run: `pnpm install`
-Expected: Clean install, no errors. `@echecs/position` is already in devDependencies so it resolves.
+Run: `pnpm install` Expected: Clean install, no errors. `@echecs/position` is
+already in devDependencies so it resolves.
 
 - [ ] **Step 3: Commit**
 
@@ -43,20 +51,30 @@ git commit -m "feat!: add @echecs/position as peer dependency"
 ### Task 2: Replace local type definitions with imports from `@echecs/position`
 
 **Files:**
+
 - Modify: `src/types.ts:1-23`
 
 - [ ] **Step 1: Replace local type definitions**
 
-Replace the first 23 lines of `src/types.ts` (everything before the `Annotations` interface) with:
+Replace the first 23 lines of `src/types.ts` (everything before the
+`Annotations` interface) with:
 
 ```typescript
-import type { Color, File, Piece, PieceType, Rank, Square } from '@echecs/position';
+import type {
+  Color,
+  File,
+  Piece,
+  PieceType,
+  Rank,
+  Square,
+} from '@echecs/position';
 import type React from 'react';
 
 type ArrowKind = 'alternative' | 'capture' | 'danger' | 'move';
 ```
 
-Remove the local definitions of `Color`, `File`, `PieceType`, `Rank`, `Square`, and `Piece` — they are now imported from `@echecs/position`.
+Remove the local definitions of `Color`, `File`, `PieceType`, `Rank`, `Square`,
+and `Piece` — they are now imported from `@echecs/position`.
 
 - [ ] **Step 2: Update `MoveEvent.promotion` type**
 
@@ -71,7 +89,9 @@ interface MoveEvent {
 }
 ```
 
-This requires `PromotionPiece` to be available. Since it's defined in `promotion-dialog.tsx`, we need to define it here instead (or inline the type). Define it above `MoveEvent`:
+This requires `PromotionPiece` to be available. Since it's defined in
+`promotion-dialog.tsx`, we need to define it here instead (or inline the type).
+Define it above `MoveEvent`:
 
 ```typescript
 type PromotionPiece = Exclude<PieceType, 'king' | 'pawn'>;
@@ -79,7 +99,8 @@ type PromotionPiece = Exclude<PieceType, 'king' | 'pawn'>;
 
 - [ ] **Step 3: Add `Color`, `Piece`, `PieceType`, `Square` to exports**
 
-In the export block at the bottom of `src/types.ts`, add re-exports. Also export `PromotionPiece` from here:
+In the export block at the bottom of `src/types.ts`, add re-exports. Also export
+`PromotionPiece` from here:
 
 ```typescript
 export type {
@@ -103,8 +124,9 @@ export type {
 
 - [ ] **Step 4: Verify types compile**
 
-Run: `pnpm lint:types`
-Expected: Type errors in files that still use old abbreviated values (`fen.ts`, `board.tsx`, `promotion-dialog.tsx`, `use-drag.ts`). That's expected — we fix those in subsequent tasks.
+Run: `pnpm lint:types` Expected: Type errors in files that still use old
+abbreviated values (`fen.ts`, `board.tsx`, `promotion-dialog.tsx`,
+`use-drag.ts`). That's expected — we fix those in subsequent tasks.
 
 - [ ] **Step 5: Commit**
 
@@ -122,12 +144,14 @@ MoveEvent.promotion is now PromotionPiece (was string)."
 ### Task 3: Update FEN parser
 
 **Files:**
+
 - Modify: `src/fen.ts:5-18`
 - Modify: `src/__tests__/fen.spec.ts`
 
 - [ ] **Step 1: Update test expectations**
 
-In `src/__tests__/fen.spec.ts`, update all `Piece` literals from abbreviated to full-word values:
+In `src/__tests__/fen.spec.ts`, update all `Piece` literals from abbreviated to
+full-word values:
 
 ```typescript
 import { describe, expect, it } from 'vitest';
@@ -200,8 +224,8 @@ describe('parseFen', () => {
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `pnpm test -- src/__tests__/fen.spec.ts`
-Expected: FAIL — assertions expect `'white'`/`'king'` but get `'w'`/`'k'`.
+Run: `pnpm test -- src/__tests__/fen.spec.ts` Expected: FAIL — assertions expect
+`'white'`/`'king'` but get `'w'`/`'k'`.
 
 - [ ] **Step 3: Update `PIECE_MAP` in `fen.ts`**
 
@@ -226,8 +250,7 @@ const PIECE_MAP: Record<string, Piece> = {
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `pnpm test -- src/__tests__/fen.spec.ts`
-Expected: All tests PASS.
+Run: `pnpm test -- src/__tests__/fen.spec.ts` Expected: All tests PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -241,11 +264,13 @@ git commit -m "feat!: update FEN parser to use full-word piece types"
 ### Task 4: Add `pieceKey` helper and update board rendering
 
 **Files:**
+
 - Modify: `src/board.tsx:1-14,162-172,307-313`
 
 - [ ] **Step 1: Add `pieceKey` helper at the top of `board.tsx`**
 
-After the imports, add a mapping function. Add imports for `Color` and `PieceType`:
+After the imports, add a mapping function. Add imports for `Color` and
+`PieceType`:
 
 ```typescript
 import type { Color, PieceType } from '@echecs/position';
@@ -288,8 +313,7 @@ Replace lines 310-311 in `src/board.tsx`:
 
 ```typescript
 // Before:
-const key: PieceKey =
-  `${piece.color}${piece.type.toUpperCase()}` as PieceKey;
+const key: PieceKey = `${piece.color}${piece.type.toUpperCase()}` as PieceKey;
 
 // After:
 const key = pieceKey(piece.color, piece.type);
@@ -297,8 +321,8 @@ const key = pieceKey(piece.color, piece.type);
 
 - [ ] **Step 4: Run board tests**
 
-Run: `pnpm test -- src/__tests__/board.spec.tsx`
-Expected: All tests PASS (board tests use FEN strings, not `Map<Square, Piece>` literals).
+Run: `pnpm test -- src/__tests__/board.spec.tsx` Expected: All tests PASS (board
+tests use FEN strings, not `Map<Square, Piece>` literals).
 
 - [ ] **Step 5: Commit**
 
@@ -312,6 +336,7 @@ git commit -m "refactor: use pieceKey helper for Piece to PieceKey mapping"
 ### Task 5: Update `use-drag.ts` — remove `turnColor` conversion
 
 **Files:**
+
 - Modify: `src/hooks/use-drag.ts:66,157,245,261,283`
 
 - [ ] **Step 1: Remove `turnColor` derivation**
@@ -325,33 +350,49 @@ const turnColor = turn === 'white' ? 'w' : turn === 'black' ? 'b' : undefined;
 
 - [ ] **Step 2: Replace all `turnColor` references with `turn`**
 
-Since `turn` is already `'black' | 'white' | undefined` and `piece.color` is now `'black' | 'white'`, replace every `turnColor` with `turn`:
+Since `turn` is already `'black' | 'white' | undefined` and `piece.color` is now
+`'black' | 'white'`, replace every `turnColor` with `turn`:
 
-Line 157: `if (piece && (!turnColor || piece.color === turnColor))` → `if (piece && (!turn || piece.color === turn))`
+Line 157: `if (piece && (!turnColor || piece.color === turnColor))` →
+`if (piece && (!turn || piece.color === turn))`
 
-Line 245: `if (reselectedPiece && (!turnColor || reselectedPiece.color === turnColor))` → `if (reselectedPiece && (!turn || reselectedPiece.color === turn))`
+Line 245:
+`if (reselectedPiece && (!turnColor || reselectedPiece.color === turnColor))` →
+`if (reselectedPiece && (!turn || reselectedPiece.color === turn))`
 
-Line 261: `if (clickedPiece && (!turnColor || clickedPiece.color === turnColor))` → `if (clickedPiece && (!turn || clickedPiece.color === turn))`
+Line 261:
+`if (clickedPiece && (!turnColor || clickedPiece.color === turnColor))` →
+`if (clickedPiece && (!turn || clickedPiece.color === turn))`
 
-Line 283: `(!turnColor || draggedPiece.color === turnColor)` → `(!turn || draggedPiece.color === turn)`
+Line 283: `(!turnColor || draggedPiece.color === turnColor)` →
+`(!turn || draggedPiece.color === turn)`
 
 - [ ] **Step 3: Remove `turnColor` from the `useCallback` dependencies**
 
-The dependency arrays that reference `turnColor` should now reference `turn` instead. Check each `useCallback`:
+The dependency arrays that reference `turnColor` should now reference `turn`
+instead. Check each `useCallback`:
 
 - `onPointerDown` deps (line 162): replace `turnColor` with `turn`
-- `onPointerUp` deps (line 306): replace `turnColor` with `turn` (it may already have `turn` from before — just ensure `turnColor` is fully removed)
+- `onPointerUp` deps (line 306): replace `turnColor` with `turn` (it may already
+  have `turn` from before — just ensure `turnColor` is fully removed)
 
-Actually, looking at the current code, the dependency arrays already don't list `turnColor` explicitly — they close over it. Since `turnColor` was a local const derived from `turn`, the hooks already list `turn` in outer scope deps. Just remove the `turnColor` line and replace all usages with `turn`.
+Actually, looking at the current code, the dependency arrays already don't list
+`turnColor` explicitly — they close over it. Since `turnColor` was a local const
+derived from `turn`, the hooks already list `turn` in outer scope deps. Just
+remove the `turnColor` line and replace all usages with `turn`.
 
-Wait — checking again. The `onPointerDown` callback at line 161-170 has deps: `[boardRef, clearAnnotations, interactive, orientation, pieces, squareSize, turnColor]`. So `turnColor` IS in the deps. Replace it with `turn`.
+Wait — checking again. The `onPointerDown` callback at line 161-170 has deps:
+`[boardRef, clearAnnotations, interactive, orientation, pieces, squareSize, turnColor]`.
+So `turnColor` IS in the deps. Replace it with `turn`.
 
-Similarly `onPointerUp` callback at line 297-307 has deps: `[attemptMove, boardRef, interactive, isLegalTarget, orientation, pieces, selectedSquare, squareSize, turnColor]`. Replace `turnColor` with `turn`.
+Similarly `onPointerUp` callback at line 297-307 has deps:
+`[attemptMove, boardRef, interactive, isLegalTarget, orientation, pieces, selectedSquare, squareSize, turnColor]`.
+Replace `turnColor` with `turn`.
 
 - [ ] **Step 4: Run all tests**
 
-Run: `pnpm test`
-Expected: All tests PASS. The board tests with `turn="white"` still work because `turn` and `piece.color` are now both `'white'`/`'black'`.
+Run: `pnpm test` Expected: All tests PASS. The board tests with `turn="white"`
+still work because `turn` and `piece.color` are now both `'white'`/`'black'`.
 
 - [ ] **Step 5: Commit**
 
@@ -368,29 +409,37 @@ No longer need turnColor conversion since Color is now
 ### Task 6: Update promotion dialog
 
 **Files:**
+
 - Modify: `src/promotion-dialog.tsx:3,6,16,25,46-48,53`
 - Modify: `src/__tests__/promotion-dialog.spec.tsx`
 
 - [ ] **Step 1: Update test expectations**
 
-In `src/__tests__/promotion-dialog.spec.tsx`, update the expected `data-promotion-piece` values and `onSelect` arguments:
+In `src/__tests__/promotion-dialog.spec.tsx`, update the expected
+`data-promotion-piece` values and `onSelect` arguments:
 
-Line 26: `expect(pieces[0]?.dataset.promotionPiece).toBe('q');` → `expect(pieces[0]?.dataset.promotionPiece).toBe('queen');`
-Line 27: `expect(pieces[1]?.dataset.promotionPiece).toBe('r');` → `expect(pieces[1]?.dataset.promotionPiece).toBe('rook');`
-Line 28: `expect(pieces[2]?.dataset.promotionPiece).toBe('b');` → `expect(pieces[2]?.dataset.promotionPiece).toBe('bishop');`
-Line 29: `expect(pieces[3]?.dataset.promotionPiece).toBe('n');` → `expect(pieces[3]?.dataset.promotionPiece).toBe('knight');`
+Line 26: `expect(pieces[0]?.dataset.promotionPiece).toBe('q');` →
+`expect(pieces[0]?.dataset.promotionPiece).toBe('queen');` Line 27:
+`expect(pieces[1]?.dataset.promotionPiece).toBe('r');` →
+`expect(pieces[1]?.dataset.promotionPiece).toBe('rook');` Line 28:
+`expect(pieces[2]?.dataset.promotionPiece).toBe('b');` →
+`expect(pieces[2]?.dataset.promotionPiece).toBe('bishop');` Line 29:
+`expect(pieces[3]?.dataset.promotionPiece).toBe('n');` →
+`expect(pieces[3]?.dataset.promotionPiece).toBe('knight');`
 
-Line 38: `'[data-promotion-piece="r"]'` → `'[data-promotion-piece="rook"]'`
-Line 41: `expect(onSelect).toHaveBeenCalledWith('r');` → `expect(onSelect).toHaveBeenCalledWith('rook');`
+Line 38: `'[data-promotion-piece="r"]'` → `'[data-promotion-piece="rook"]'` Line
+41: `expect(onSelect).toHaveBeenCalledWith('r');` →
+`expect(onSelect).toHaveBeenCalledWith('rook');`
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `pnpm test -- src/__tests__/promotion-dialog.spec.tsx`
-Expected: FAIL — pieces still have abbreviated values.
+Run: `pnpm test -- src/__tests__/promotion-dialog.spec.tsx` Expected: FAIL —
+pieces still have abbreviated values.
 
 - [ ] **Step 3: Update `promotion-dialog.tsx`**
 
-Import `PromotionPiece` from types instead of defining locally. Import `Color` and `PieceType` for the mapping:
+Import `PromotionPiece` from types instead of defining locally. Import `Color`
+and `PieceType` for the mapping:
 
 ```typescript
 import { DEFAULT_PIECES } from './pieces/index.js';
@@ -405,7 +454,12 @@ Remove the local `type PromotionPiece = 'b' | 'n' | 'q' | 'r';` definition.
 Update `PROMOTION_PIECES`:
 
 ```typescript
-const PROMOTION_PIECES: PromotionPiece[] = ['queen', 'rook', 'bishop', 'knight'];
+const PROMOTION_PIECES: PromotionPiece[] = [
+  'queen',
+  'rook',
+  'bishop',
+  'knight',
+];
 ```
 
 Update `colorPrefix` mapping (line 25):
@@ -420,7 +474,8 @@ Replace the inline `colorPrefix` derivation with:
 const colorPrefix = COLOR_PREFIX[color];
 ```
 
-Update the `PieceKey` construction inside the map (line 47-48). The piece is now `'queen'`, `'rook'`, etc. We need to map to the uppercase single char:
+Update the `PieceKey` construction inside the map (line 47-48). The piece is now
+`'queen'`, `'rook'`, etc. We need to map to the uppercase single char:
 
 ```typescript
 const TYPE_KEY: Record<PromotionPiece, string> = {
@@ -439,7 +494,8 @@ const key: PieceKey = `${colorPrefix}${TYPE_KEY[piece]}` as PieceKey;
 
 - [ ] **Step 4: Update exports**
 
-Remove the `PromotionPiece` export from `promotion-dialog.tsx` since it's now exported from `types.ts`:
+Remove the `PromotionPiece` export from `promotion-dialog.tsx` since it's now
+exported from `types.ts`:
 
 ```typescript
 export { PromotionDialog };
@@ -448,7 +504,8 @@ export type { PromotionDialogProperties as PromotionDialogProps };
 
 - [ ] **Step 5: Update `src/index.ts`**
 
-Move `PromotionPiece` export from the promotion-dialog re-export to the types re-export:
+Move `PromotionPiece` export from the promotion-dialog re-export to the types
+re-export:
 
 ```typescript
 export type {
@@ -475,8 +532,8 @@ export type { SquareCoords } from './utilities.js';
 
 - [ ] **Step 6: Run tests to verify they pass**
 
-Run: `pnpm test -- src/__tests__/promotion-dialog.spec.tsx`
-Expected: All tests PASS.
+Run: `pnpm test -- src/__tests__/promotion-dialog.spec.tsx` Expected: All tests
+PASS.
 
 - [ ] **Step 7: Commit**
 
@@ -493,9 +550,11 @@ BREAKING CHANGE: PromotionPiece is now 'bishop' | 'knight' | 'queen' | 'rook'
 ### Task 7: Update stories — remove conversion helpers
 
 **Files:**
+
 - Modify: `src/__stories__/board.stories.tsx:236-264,353-361`
 
-- [ ] **Step 1: Remove `COLOR_MAP`, `TYPE_MAP`, `PROMOTION_MAP` and simplify `toPosition`**
+- [ ] **Step 1: Remove `COLOR_MAP`, `TYPE_MAP`, `PROMOTION_MAP` and simplify
+      `toPosition`**
 
 Remove lines 236-250 (`COLOR_MAP`, `PROMOTION_MAP`, `TYPE_MAP`).
 
@@ -507,11 +566,16 @@ function toPosition(game: Game): Map<Square, Piece> {
 }
 ```
 
-Since `game.position().pieces()` returns `Map<Square, Piece>` from `@echecs/position` and react-board's `Piece` is now the same type, the cast is just to satisfy the import path difference (both are structurally identical).
+Since `game.position().pieces()` returns `Map<Square, Piece>` from
+`@echecs/position` and react-board's `Piece` is now the same type, the cast is
+just to satisfy the import path difference (both are structurally identical).
 
 - [ ] **Step 2: Update `handlePromotion` callback**
 
-The `handlePromotion` callback (around line 353) currently receives a `string` and maps through `PROMOTION_MAP`. Since `PromotionPiece` is now `'bishop' | 'knight' | 'queen' | 'rook'` — which is exactly what `@echecs/game` expects — simplify:
+The `handlePromotion` callback (around line 353) currently receives a `string`
+and maps through `PROMOTION_MAP`. Since `PromotionPiece` is now
+`'bishop' | 'knight' | 'queen' | 'rook'` — which is exactly what `@echecs/game`
+expects — simplify:
 
 ```typescript
 const handlePromotion = useCallback(
@@ -538,12 +602,13 @@ const handlePromotion = useCallback(
 
 - [ ] **Step 3: Remove unused imports**
 
-Check that `Piece` is still needed in the imports (yes — used in `toPosition` return type). Remove `PieceKey` from imports if it's no longer used directly in stories. Looking at line 179, `PIECE_KEYS` uses `PieceKey[]` — keep it.
+Check that `Piece` is still needed in the imports (yes — used in `toPosition`
+return type). Remove `PieceKey` from imports if it's no longer used directly in
+stories. Looking at line 179, `PIECE_KEYS` uses `PieceKey[]` — keep it.
 
 - [ ] **Step 4: Verify storybook builds**
 
-Run: `pnpm storybook:build`
-Expected: Build succeeds without errors.
+Run: `pnpm storybook:build` Expected: Build succeeds without errors.
 
 - [ ] **Step 5: Commit**
 
@@ -560,23 +625,22 @@ Types now align directly between @echecs/game and react-board."
 
 - [ ] **Step 1: Run all tests**
 
-Run: `pnpm test`
-Expected: All tests PASS.
+Run: `pnpm test` Expected: All tests PASS.
 
 - [ ] **Step 2: Run linter**
 
-Run: `pnpm lint`
-Expected: No errors.
+Run: `pnpm lint` Expected: No errors.
 
 - [ ] **Step 3: Run build**
 
-Run: `pnpm build`
-Expected: Build succeeds. Verify `dist/index.d.ts` re-exports the new types.
+Run: `pnpm build` Expected: Build succeeds. Verify `dist/index.d.ts` re-exports
+the new types.
 
 - [ ] **Step 4: Verify exported types in dist**
 
-Run: `grep -E 'Color|PieceType|PromotionPiece' dist/index.d.ts`
-Expected: `Color`, `PieceType`, `Piece`, `Square`, `PromotionPiece` are present in the type exports.
+Run: `grep -E 'Color|PieceType|PromotionPiece' dist/index.d.ts` Expected:
+`Color`, `PieceType`, `Piece`, `Square`, `PromotionPiece` are present in the
+type exports.
 
 - [ ] **Step 5: Commit any remaining changes (if any)**
 

--- a/docs/superpowers/plans/2026-05-01-align-piece-types.md
+++ b/docs/superpowers/plans/2026-05-01-align-piece-types.md
@@ -1,0 +1,588 @@
+# Align Piece Types with @echecs/position — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace locally defined `Color`, `PieceType`, `Piece`, `File`, `Rank`, `Square` types with imports from `@echecs/position` so consumers can pass position data directly without conversion.
+
+**Architecture:** Import domain types from `@echecs/position` (peer dep). Keep `PieceKey`/`PieceSet` as-is for rendering. Add internal mapping from `Piece` → `PieceKey`. Update FEN parser values, promotion dialog, and tests.
+
+**Tech Stack:** TypeScript, React, vitest, @echecs/position@^3
+
+---
+
+### Task 1: Add `@echecs/position` as peer dependency
+
+**Files:**
+- Modify: `package.json:53-55`
+
+- [ ] **Step 1: Add `@echecs/position` to peerDependencies**
+
+In `package.json`, add `@echecs/position` to the existing `peerDependencies`:
+
+```json
+"peerDependencies": {
+  "@echecs/position": ">=3",
+  "react": ">=18"
+}
+```
+
+- [ ] **Step 2: Verify install**
+
+Run: `pnpm install`
+Expected: Clean install, no errors. `@echecs/position` is already in devDependencies so it resolves.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml
+git commit -m "feat!: add @echecs/position as peer dependency"
+```
+
+---
+
+### Task 2: Replace local type definitions with imports from `@echecs/position`
+
+**Files:**
+- Modify: `src/types.ts:1-23`
+
+- [ ] **Step 1: Replace local type definitions**
+
+Replace the first 23 lines of `src/types.ts` (everything before the `Annotations` interface) with:
+
+```typescript
+import type { Color, File, Piece, PieceType, Rank, Square } from '@echecs/position';
+import type React from 'react';
+
+type ArrowKind = 'alternative' | 'capture' | 'danger' | 'move';
+```
+
+Remove the local definitions of `Color`, `File`, `PieceType`, `Rank`, `Square`, and `Piece` — they are now imported from `@echecs/position`.
+
+- [ ] **Step 2: Update `MoveEvent.promotion` type**
+
+In `src/types.ts`, change the `MoveEvent` interface:
+
+```typescript
+interface MoveEvent {
+  capture: boolean;
+  from: Square;
+  promotion?: PromotionPiece;
+  to: Square;
+}
+```
+
+This requires `PromotionPiece` to be available. Since it's defined in `promotion-dialog.tsx`, we need to define it here instead (or inline the type). Define it above `MoveEvent`:
+
+```typescript
+type PromotionPiece = Exclude<PieceType, 'king' | 'pawn'>;
+```
+
+- [ ] **Step 3: Add `Color`, `Piece`, `PieceType`, `Square` to exports**
+
+In the export block at the bottom of `src/types.ts`, add re-exports. Also export `PromotionPiece` from here:
+
+```typescript
+export type {
+  Annotations,
+  Arrow,
+  ArrowKind,
+  BoardProperties as BoardProps,
+  Circle,
+  Color,
+  File,
+  MoveEvent,
+  Piece,
+  PieceKey,
+  PieceSet,
+  PieceType,
+  PromotionPiece,
+  Rank,
+  Square,
+};
+```
+
+- [ ] **Step 4: Verify types compile**
+
+Run: `pnpm lint:types`
+Expected: Type errors in files that still use old abbreviated values (`fen.ts`, `board.tsx`, `promotion-dialog.tsx`, `use-drag.ts`). That's expected — we fix those in subsequent tasks.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types.ts
+git commit -m "feat!: import piece types from @echecs/position
+
+BREAKING CHANGE: Color is now 'black' | 'white' (was 'b' | 'w').
+PieceType is now 'bishop' | 'king' | ... (was 'b' | 'k' | ...).
+MoveEvent.promotion is now PromotionPiece (was string)."
+```
+
+---
+
+### Task 3: Update FEN parser
+
+**Files:**
+- Modify: `src/fen.ts:5-18`
+- Modify: `src/__tests__/fen.spec.ts`
+
+- [ ] **Step 1: Update test expectations**
+
+In `src/__tests__/fen.spec.ts`, update all `Piece` literals from abbreviated to full-word values:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+
+import { parseFen } from '../fen.js';
+
+const STARTING_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+
+const AFTER_E4_FEN =
+  'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1';
+
+describe('parseFen', () => {
+  describe('starting position', () => {
+    it('has 32 pieces', () => {
+      const pos = parseFen(STARTING_FEN);
+      expect(pos.size).toBe(32);
+    });
+
+    it('has white king on e1', () => {
+      const pos = parseFen(STARTING_FEN);
+      expect(pos.get('e1')).toEqual({ color: 'white', type: 'king' });
+    });
+
+    it('has black king on e8', () => {
+      const pos = parseFen(STARTING_FEN);
+      expect(pos.get('e8')).toEqual({ color: 'black', type: 'king' });
+    });
+
+    it('has white pawns on rank 2', () => {
+      const pos = parseFen(STARTING_FEN);
+      for (const file of ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']) {
+        expect(pos.get(`${file}2` as Parameters<typeof pos.get>[0])).toEqual({
+          color: 'white',
+          type: 'pawn',
+        });
+      }
+    });
+
+    it('has black pawns on rank 7', () => {
+      const pos = parseFen(STARTING_FEN);
+      for (const file of ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']) {
+        expect(pos.get(`${file}7` as Parameters<typeof pos.get>[0])).toEqual({
+          color: 'black',
+          type: 'pawn',
+        });
+      }
+    });
+  });
+
+  describe('after 1.e4', () => {
+    it('has pawn on e4', () => {
+      const pos = parseFen(AFTER_E4_FEN);
+      expect(pos.get('e4')).toEqual({ color: 'white', type: 'pawn' });
+    });
+
+    it('has empty e2', () => {
+      const pos = parseFen(AFTER_E4_FEN);
+      expect(pos.get('e2')).toBeUndefined();
+    });
+  });
+
+  describe('empty board', () => {
+    it('has 0 pieces', () => {
+      const pos = parseFen('8/8/8/8/8/8/8/8 w - - 0 1');
+      expect(pos.size).toBe(0);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test -- src/__tests__/fen.spec.ts`
+Expected: FAIL — assertions expect `'white'`/`'king'` but get `'w'`/`'k'`.
+
+- [ ] **Step 3: Update `PIECE_MAP` in `fen.ts`**
+
+Replace `PIECE_MAP` in `src/fen.ts` (lines 5-18):
+
+```typescript
+const PIECE_MAP: Record<string, Piece> = {
+  B: { color: 'white', type: 'bishop' },
+  K: { color: 'white', type: 'king' },
+  N: { color: 'white', type: 'knight' },
+  P: { color: 'white', type: 'pawn' },
+  Q: { color: 'white', type: 'queen' },
+  R: { color: 'white', type: 'rook' },
+  b: { color: 'black', type: 'bishop' },
+  k: { color: 'black', type: 'king' },
+  n: { color: 'black', type: 'knight' },
+  p: { color: 'black', type: 'pawn' },
+  q: { color: 'black', type: 'queen' },
+  r: { color: 'black', type: 'rook' },
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test -- src/__tests__/fen.spec.ts`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/fen.ts src/__tests__/fen.spec.ts
+git commit -m "feat!: update FEN parser to use full-word piece types"
+```
+
+---
+
+### Task 4: Add `pieceKey` helper and update board rendering
+
+**Files:**
+- Modify: `src/board.tsx:1-14,162-172,307-313`
+
+- [ ] **Step 1: Add `pieceKey` helper at the top of `board.tsx`**
+
+After the imports, add a mapping function. Add imports for `Color` and `PieceType`:
+
+```typescript
+import type { Color, PieceType } from '@echecs/position';
+```
+
+Then after `STARTING_FEN`:
+
+```typescript
+const COLOR_PREFIX: Record<Color, 'b' | 'w'> = { black: 'b', white: 'w' };
+const TYPE_SUFFIX: Record<PieceType, string> = {
+  bishop: 'B',
+  king: 'K',
+  knight: 'N',
+  pawn: 'P',
+  queen: 'Q',
+  rook: 'R',
+};
+
+function pieceKey(color: Color, type: PieceType): PieceKey {
+  return `${COLOR_PREFIX[color]}${TYPE_SUFFIX[type]}` as PieceKey;
+}
+```
+
+- [ ] **Step 2: Update ghost piece key construction**
+
+Replace lines 168-169 in `src/board.tsx`:
+
+```typescript
+// Before:
+const ghostKey: PieceKey =
+  `${ghostPiece.color}${ghostPiece.type.toUpperCase()}` as PieceKey;
+
+// After:
+const ghostKey = pieceKey(ghostPiece.color, ghostPiece.type);
+```
+
+- [ ] **Step 3: Update rendered piece key construction**
+
+Replace lines 310-311 in `src/board.tsx`:
+
+```typescript
+// Before:
+const key: PieceKey =
+  `${piece.color}${piece.type.toUpperCase()}` as PieceKey;
+
+// After:
+const key = pieceKey(piece.color, piece.type);
+```
+
+- [ ] **Step 4: Run board tests**
+
+Run: `pnpm test -- src/__tests__/board.spec.tsx`
+Expected: All tests PASS (board tests use FEN strings, not `Map<Square, Piece>` literals).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/board.tsx
+git commit -m "refactor: use pieceKey helper for Piece to PieceKey mapping"
+```
+
+---
+
+### Task 5: Update `use-drag.ts` — remove `turnColor` conversion
+
+**Files:**
+- Modify: `src/hooks/use-drag.ts:66,157,245,261,283`
+
+- [ ] **Step 1: Remove `turnColor` derivation**
+
+In `src/hooks/use-drag.ts`, remove line 66:
+
+```typescript
+// Remove this line:
+const turnColor = turn === 'white' ? 'w' : turn === 'black' ? 'b' : undefined;
+```
+
+- [ ] **Step 2: Replace all `turnColor` references with `turn`**
+
+Since `turn` is already `'black' | 'white' | undefined` and `piece.color` is now `'black' | 'white'`, replace every `turnColor` with `turn`:
+
+Line 157: `if (piece && (!turnColor || piece.color === turnColor))` → `if (piece && (!turn || piece.color === turn))`
+
+Line 245: `if (reselectedPiece && (!turnColor || reselectedPiece.color === turnColor))` → `if (reselectedPiece && (!turn || reselectedPiece.color === turn))`
+
+Line 261: `if (clickedPiece && (!turnColor || clickedPiece.color === turnColor))` → `if (clickedPiece && (!turn || clickedPiece.color === turn))`
+
+Line 283: `(!turnColor || draggedPiece.color === turnColor)` → `(!turn || draggedPiece.color === turn)`
+
+- [ ] **Step 3: Remove `turnColor` from the `useCallback` dependencies**
+
+The dependency arrays that reference `turnColor` should now reference `turn` instead. Check each `useCallback`:
+
+- `onPointerDown` deps (line 162): replace `turnColor` with `turn`
+- `onPointerUp` deps (line 306): replace `turnColor` with `turn` (it may already have `turn` from before — just ensure `turnColor` is fully removed)
+
+Actually, looking at the current code, the dependency arrays already don't list `turnColor` explicitly — they close over it. Since `turnColor` was a local const derived from `turn`, the hooks already list `turn` in outer scope deps. Just remove the `turnColor` line and replace all usages with `turn`.
+
+Wait — checking again. The `onPointerDown` callback at line 161-170 has deps: `[boardRef, clearAnnotations, interactive, orientation, pieces, squareSize, turnColor]`. So `turnColor` IS in the deps. Replace it with `turn`.
+
+Similarly `onPointerUp` callback at line 297-307 has deps: `[attemptMove, boardRef, interactive, isLegalTarget, orientation, pieces, selectedSquare, squareSize, turnColor]`. Replace `turnColor` with `turn`.
+
+- [ ] **Step 4: Run all tests**
+
+Run: `pnpm test`
+Expected: All tests PASS. The board tests with `turn="white"` still work because `turn` and `piece.color` are now both `'white'`/`'black'`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/use-drag.ts
+git commit -m "refactor: compare turn directly against piece.color
+
+No longer need turnColor conversion since Color is now
+'black' | 'white', matching the turn prop."
+```
+
+---
+
+### Task 6: Update promotion dialog
+
+**Files:**
+- Modify: `src/promotion-dialog.tsx:3,6,16,25,46-48,53`
+- Modify: `src/__tests__/promotion-dialog.spec.tsx`
+
+- [ ] **Step 1: Update test expectations**
+
+In `src/__tests__/promotion-dialog.spec.tsx`, update the expected `data-promotion-piece` values and `onSelect` arguments:
+
+Line 26: `expect(pieces[0]?.dataset.promotionPiece).toBe('q');` → `expect(pieces[0]?.dataset.promotionPiece).toBe('queen');`
+Line 27: `expect(pieces[1]?.dataset.promotionPiece).toBe('r');` → `expect(pieces[1]?.dataset.promotionPiece).toBe('rook');`
+Line 28: `expect(pieces[2]?.dataset.promotionPiece).toBe('b');` → `expect(pieces[2]?.dataset.promotionPiece).toBe('bishop');`
+Line 29: `expect(pieces[3]?.dataset.promotionPiece).toBe('n');` → `expect(pieces[3]?.dataset.promotionPiece).toBe('knight');`
+
+Line 38: `'[data-promotion-piece="r"]'` → `'[data-promotion-piece="rook"]'`
+Line 41: `expect(onSelect).toHaveBeenCalledWith('r');` → `expect(onSelect).toHaveBeenCalledWith('rook');`
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test -- src/__tests__/promotion-dialog.spec.tsx`
+Expected: FAIL — pieces still have abbreviated values.
+
+- [ ] **Step 3: Update `promotion-dialog.tsx`**
+
+Import `PromotionPiece` from types instead of defining locally. Import `Color` and `PieceType` for the mapping:
+
+```typescript
+import { DEFAULT_PIECES } from './pieces/index.js';
+
+import type { PieceKey, PieceSet, PromotionPiece } from './types.js';
+import type { Color } from '@echecs/position';
+import type React from 'react';
+```
+
+Remove the local `type PromotionPiece = 'b' | 'n' | 'q' | 'r';` definition.
+
+Update `PROMOTION_PIECES`:
+
+```typescript
+const PROMOTION_PIECES: PromotionPiece[] = ['queen', 'rook', 'bishop', 'knight'];
+```
+
+Update `colorPrefix` mapping (line 25):
+
+```typescript
+const COLOR_PREFIX: Record<Color, 'b' | 'w'> = { black: 'b', white: 'w' };
+```
+
+Replace the inline `colorPrefix` derivation with:
+
+```typescript
+const colorPrefix = COLOR_PREFIX[color];
+```
+
+Update the `PieceKey` construction inside the map (line 47-48). The piece is now `'queen'`, `'rook'`, etc. We need to map to the uppercase single char:
+
+```typescript
+const TYPE_KEY: Record<PromotionPiece, string> = {
+  bishop: 'B',
+  knight: 'N',
+  queen: 'Q',
+  rook: 'R',
+};
+```
+
+Then in the map callback:
+
+```typescript
+const key: PieceKey = `${colorPrefix}${TYPE_KEY[piece]}` as PieceKey;
+```
+
+- [ ] **Step 4: Update exports**
+
+Remove the `PromotionPiece` export from `promotion-dialog.tsx` since it's now exported from `types.ts`:
+
+```typescript
+export { PromotionDialog };
+export type { PromotionDialogProperties as PromotionDialogProps };
+```
+
+- [ ] **Step 5: Update `src/index.ts`**
+
+Move `PromotionPiece` export from the promotion-dialog re-export to the types re-export:
+
+```typescript
+export type {
+  Annotations,
+  Arrow,
+  ArrowKind,
+  BoardProps,
+  Circle,
+  Color,
+  File,
+  MoveEvent,
+  Piece,
+  PieceKey,
+  PieceSet,
+  PieceType,
+  PromotionPiece,
+  Rank,
+  Square,
+} from './types.js';
+
+export type { PromotionDialogProps } from './promotion-dialog.js';
+export type { SquareCoords } from './utilities.js';
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pnpm test -- src/__tests__/promotion-dialog.spec.tsx`
+Expected: All tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/promotion-dialog.tsx src/types.ts src/index.ts src/__tests__/promotion-dialog.spec.tsx
+git commit -m "feat!: update PromotionPiece to use full-word values
+
+BREAKING CHANGE: PromotionPiece is now 'bishop' | 'knight' | 'queen' | 'rook'
+(was 'b' | 'n' | 'q' | 'r')."
+```
+
+---
+
+### Task 7: Update stories — remove conversion helpers
+
+**Files:**
+- Modify: `src/__stories__/board.stories.tsx:236-264,353-361`
+
+- [ ] **Step 1: Remove `COLOR_MAP`, `TYPE_MAP`, `PROMOTION_MAP` and simplify `toPosition`**
+
+Remove lines 236-250 (`COLOR_MAP`, `PROMOTION_MAP`, `TYPE_MAP`).
+
+Replace `toPosition` (lines 252-264) with:
+
+```typescript
+function toPosition(game: Game): Map<Square, Piece> {
+  return game.position().pieces() as Map<Square, Piece>;
+}
+```
+
+Since `game.position().pieces()` returns `Map<Square, Piece>` from `@echecs/position` and react-board's `Piece` is now the same type, the cast is just to satisfy the import path difference (both are structurally identical).
+
+- [ ] **Step 2: Update `handlePromotion` callback**
+
+The `handlePromotion` callback (around line 353) currently receives a `string` and maps through `PROMOTION_MAP`. Since `PromotionPiece` is now `'bishop' | 'knight' | 'queen' | 'rook'` — which is exactly what `@echecs/game` expects — simplify:
+
+```typescript
+const handlePromotion = useCallback(
+  (piece: string) => {
+    if (!pendingPromotion) return;
+    try {
+      gameReference.current.move({
+        from: pendingPromotion.from,
+        promotion: piece as never,
+        to: pendingPromotion.to,
+      });
+      playSound(pendingPromotion, false);
+      syncState();
+    } catch {
+      // invalid promotion
+    }
+    setPendingPromotion(undefined);
+  },
+  [pendingPromotion, playSound, syncState],
+);
+```
+
+(Removed the `PROMOTION_MAP` lookup — `piece` is already the right value.)
+
+- [ ] **Step 3: Remove unused imports**
+
+Check that `Piece` is still needed in the imports (yes — used in `toPosition` return type). Remove `PieceKey` from imports if it's no longer used directly in stories. Looking at line 179, `PIECE_KEYS` uses `PieceKey[]` — keep it.
+
+- [ ] **Step 4: Verify storybook builds**
+
+Run: `pnpm storybook:build`
+Expected: Build succeeds without errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/__stories__/board.stories.tsx
+git commit -m "refactor: remove type conversion helpers from stories
+
+Types now align directly between @echecs/game and react-board."
+```
+
+---
+
+### Task 8: Full verification
+
+- [ ] **Step 1: Run all tests**
+
+Run: `pnpm test`
+Expected: All tests PASS.
+
+- [ ] **Step 2: Run linter**
+
+Run: `pnpm lint`
+Expected: No errors.
+
+- [ ] **Step 3: Run build**
+
+Run: `pnpm build`
+Expected: Build succeeds. Verify `dist/index.d.ts` re-exports the new types.
+
+- [ ] **Step 4: Verify exported types in dist**
+
+Run: `grep -E 'Color|PieceType|PromotionPiece' dist/index.d.ts`
+Expected: `Color`, `PieceType`, `Piece`, `Square`, `PromotionPiece` are present in the type exports.
+
+- [ ] **Step 5: Commit any remaining changes (if any)**
+
+If lint auto-fixed anything:
+
+```bash
+git add -A
+git commit -m "chore: lint fixes"
+```

--- a/docs/superpowers/specs/2026-05-01-align-piece-types-design.md
+++ b/docs/superpowers/specs/2026-05-01-align-piece-types-design.md
@@ -1,0 +1,153 @@
+# align piece types with @echecs/position
+
+**issue:** [#57](https://github.com/echecsjs/react-board/issues/57)
+**breaking:** yes — major version bump required
+
+## background
+
+react-board used to import `Piece` and `Square` from `@echecs/position@^1.0.0`,
+which had abbreviated types (`'b'|'w'`, `'b'|'k'|'n'|...`). PR #39 inlined
+those types locally and dropped the dependency entirely.
+
+`@echecs/position` has since moved to v3 with full-word types
+(`'black'|'white'`, `'bishop'|'king'|'knight'|...`). this means consumers using
+both packages must manually convert between the two type systems — the stories
+already have `COLOR_MAP` / `TYPE_MAP` helpers doing exactly this.
+
+## changes
+
+### types — import from `@echecs/position`
+
+replace locally defined types with imports from `@echecs/position`:
+
+| type        | current (local)                          | new (from position)                                          |
+|-------------|------------------------------------------|--------------------------------------------------------------|
+| `Color`     | `'b' \| 'w'`                            | `'black' \| 'white'`                                        |
+| `PieceType` | `'b' \| 'k' \| 'n' \| 'p' \| 'q' \| 'r'` | `'bishop' \| 'king' \| 'knight' \| 'pawn' \| 'queen' \| 'rook'` |
+| `Piece`     | `{ color: Color; type: PieceType }`      | same shape, different literal values                         |
+| `File`      | `'a' \| 'b' \| ... \| 'h'`              | identical — import for consistency                           |
+| `Rank`      | `'1' \| '2' \| ... \| '8'`              | identical — import for consistency                           |
+| `Square`    | `` `${File}${Rank}` ``                   | identical — import for consistency                           |
+
+re-export `Color`, `File`, `PieceType`, `Piece`, `Rank`, `Square` from the
+package entry point so consumers don't need to install `@echecs/position` just
+to type a `Piece`.
+
+### `PromotionPiece` — align with `PieceType`
+
+current: `'b' | 'n' | 'q' | 'r'`
+new: `'bishop' | 'knight' | 'queen' | 'rook'`
+
+this is an exported type used in the `PromotionDialog` `onSelect` callback.
+
+### `MoveEvent.promotion` — type narrowly
+
+current: `promotion?: string`
+new: `promotion?: PromotionPiece`
+
+since `PromotionPiece` now uses full-word values, the promotion field becomes
+properly typed instead of an opaque string.
+
+### `PieceKey` and `PieceSet` — unchanged
+
+`PieceKey` stays as `'bB' | 'wK' | ...` — this is a rendering/theming concern
+(sprite-sheet lookup), not a domain concern. decoupling it from the domain types
+keeps the breaking surface smaller and the keys compact.
+
+internal code that converts `Piece` → `PieceKey` needs a small mapping:
+
+```typescript
+const COLOR_PREFIX: Record<Color, 'b' | 'w'> = { black: 'b', white: 'w' };
+const TYPE_SUFFIX: Record<PieceType, string> = {
+  bishop: 'B', king: 'K', knight: 'N', pawn: 'P', queen: 'Q', rook: 'R',
+};
+
+function pieceKey(piece: Piece): PieceKey {
+  return `${COLOR_PREFIX[piece.color]}${TYPE_SUFFIX[piece.type]}` as PieceKey;
+}
+```
+
+### FEN parsing — update `PIECE_MAP` values
+
+`fen.ts` maps FEN characters to `Piece` objects. the values change:
+
+```typescript
+const PIECE_MAP: Record<string, Piece> = {
+  B: { color: 'white', type: 'bishop' },
+  K: { color: 'white', type: 'king' },
+  // ... etc
+  b: { color: 'black', type: 'bishop' },
+  k: { color: 'black', type: 'king' },
+  // ... etc
+};
+```
+
+### dependency — add `@echecs/position` as peer dep
+
+```json
+{
+  "peerDependencies": {
+    "@echecs/position": ">=3",
+    "react": ">=18"
+  }
+}
+```
+
+type-only usage — no runtime import. consumers using only FEN strings don't
+interact with position's types at runtime, but typescript needs the package
+installed to resolve the type imports.
+
+keep `@echecs/position` in `devDependencies` as well for local development.
+
+### stories cleanup
+
+remove `COLOR_MAP`, `TYPE_MAP`, and `PROMOTION_MAP` from
+`board.stories.tsx`. the `toPosition()` helper becomes a direct passthrough
+since `game.position().pieces()` already returns `Map<Square, Piece>` with the
+right types. `PROMOTION_MAP` goes away because `PromotionPiece` values now match
+what `@echecs/game` expects.
+
+### `orientation` and `turn` props
+
+already use `'black' | 'white'` — no change needed.
+
+## files affected
+
+| file                              | change                                              |
+|-----------------------------------|-----------------------------------------------------|
+| `src/types.ts`                    | import types from position, update `PromotionPiece`, type `MoveEvent.promotion` |
+| `src/index.ts`                    | re-export `Color`, `File`, `Piece`, `PieceType`, `Rank`, `Square` |
+| `src/fen.ts`                      | update `PIECE_MAP` values                           |
+| `src/board.tsx`                   | add `Piece` → `PieceKey` mapping                    |
+| `src/promotion-dialog.tsx`        | update `PromotionPiece` values, `colorPrefix` mapping |
+| `src/utilities.ts`                | no change (uses `Piece`/`Square` by shape)           |
+| `src/hooks/use-drag.ts`           | no change (uses types by shape)                      |
+| `src/hooks/use-animation.ts`      | no change (uses types by shape)                      |
+| `src/__stories__/board.stories.tsx`| remove conversion helpers                           |
+| `src/__tests__/fen.spec.ts`       | update expected `Piece` values in assertions         |
+| `src/__tests__/board.spec.tsx`    | update any `Piece` literals in test data             |
+| `src/__tests__/promotion-dialog.spec.tsx` | update expected `PromotionPiece` values      |
+| `package.json`                    | add `@echecs/position` to peerDependencies           |
+
+## what does NOT change
+
+- `PieceKey` type (`'bB' | 'wK' | ...`)
+- `PieceSet` type (`Record<PieceKey, string>`)
+- `DEFAULT_PIECES` constant
+- CSS variable names
+- SVG piece assets
+- board rendering logic (grid, coordinates, drag & drop)
+- animation system
+- annotation overlay
+
+## breaking change surface
+
+consumers must update if they:
+1. pass `Map<Square, Piece>` to the `position` prop — piece values change
+2. handle `PromotionPiece` from `PromotionDialog.onSelect` — values change
+3. read `MoveEvent.promotion` — now typed as `PromotionPiece` instead of `string`
+
+consumers are unaffected if they:
+- use FEN strings for position
+- pass custom `PieceSet` (keys unchanged)
+- only use `onMove`, `onSquareClick` callbacks with `Square` values

--- a/docs/superpowers/specs/2026-05-01-align-piece-types-design.md
+++ b/docs/superpowers/specs/2026-05-01-align-piece-types-design.md
@@ -6,8 +6,8 @@
 ## background
 
 react-board used to import `Piece` and `Square` from `@echecs/position@^1.0.0`,
-which had abbreviated types (`'b'|'w'`, `'b'|'k'|'n'|...`). PR #39 inlined
-those types locally and dropped the dependency entirely.
+which had abbreviated types (`'b'|'w'`, `'b'|'k'|'n'|...`). PR #39 inlined those
+types locally and dropped the dependency entirely.
 
 `@echecs/position` has since moved to v3 with full-word types
 (`'black'|'white'`, `'bishop'|'king'|'knight'|...`). this means consumers using
@@ -20,14 +20,14 @@ already have `COLOR_MAP` / `TYPE_MAP` helpers doing exactly this.
 
 replace locally defined types with imports from `@echecs/position`:
 
-| type        | current (local)                          | new (from position)                                          |
-|-------------|------------------------------------------|--------------------------------------------------------------|
-| `Color`     | `'b' \| 'w'`                            | `'black' \| 'white'`                                        |
+| type        | current (local)                          | new (from position)                                             |
+| ----------- | ---------------------------------------- | --------------------------------------------------------------- |
+| `Color`     | `'b' \| 'w'`                             | `'black' \| 'white'`                                            |
 | `PieceType` | `'b' \| 'k' \| 'n' \| 'p' \| 'q' \| 'r'` | `'bishop' \| 'king' \| 'knight' \| 'pawn' \| 'queen' \| 'rook'` |
-| `Piece`     | `{ color: Color; type: PieceType }`      | same shape, different literal values                         |
-| `File`      | `'a' \| 'b' \| ... \| 'h'`              | identical — import for consistency                           |
-| `Rank`      | `'1' \| '2' \| ... \| '8'`              | identical — import for consistency                           |
-| `Square`    | `` `${File}${Rank}` ``                   | identical — import for consistency                           |
+| `Piece`     | `{ color: Color; type: PieceType }`      | same shape, different literal values                            |
+| `File`      | `'a' \| 'b' \| ... \| 'h'`               | identical — import for consistency                              |
+| `Rank`      | `'1' \| '2' \| ... \| '8'`               | identical — import for consistency                              |
+| `Square`    | `` `${File}${Rank}` ``                   | identical — import for consistency                              |
 
 re-export `Color`, `File`, `PieceType`, `Piece`, `Rank`, `Square` from the
 package entry point so consumers don't need to install `@echecs/position` just
@@ -35,15 +35,13 @@ to type a `Piece`.
 
 ### `PromotionPiece` — align with `PieceType`
 
-current: `'b' | 'n' | 'q' | 'r'`
-new: `'bishop' | 'knight' | 'queen' | 'rook'`
+current: `'b' | 'n' | 'q' | 'r'` new: `'bishop' | 'knight' | 'queen' | 'rook'`
 
 this is an exported type used in the `PromotionDialog` `onSelect` callback.
 
 ### `MoveEvent.promotion` — type narrowly
 
-current: `promotion?: string`
-new: `promotion?: PromotionPiece`
+current: `promotion?: string` new: `promotion?: PromotionPiece`
 
 since `PromotionPiece` now uses full-word values, the promotion field becomes
 properly typed instead of an opaque string.
@@ -59,7 +57,12 @@ internal code that converts `Piece` → `PieceKey` needs a small mapping:
 ```typescript
 const COLOR_PREFIX: Record<Color, 'b' | 'w'> = { black: 'b', white: 'w' };
 const TYPE_SUFFIX: Record<PieceType, string> = {
-  bishop: 'B', king: 'K', knight: 'N', pawn: 'P', queen: 'Q', rook: 'R',
+  bishop: 'B',
+  king: 'K',
+  knight: 'N',
+  pawn: 'P',
+  queen: 'Q',
+  rook: 'R',
 };
 
 function pieceKey(piece: Piece): PieceKey {
@@ -101,11 +104,11 @@ keep `@echecs/position` in `devDependencies` as well for local development.
 
 ### stories cleanup
 
-remove `COLOR_MAP`, `TYPE_MAP`, and `PROMOTION_MAP` from
-`board.stories.tsx`. the `toPosition()` helper becomes a direct passthrough
-since `game.position().pieces()` already returns `Map<Square, Piece>` with the
-right types. `PROMOTION_MAP` goes away because `PromotionPiece` values now match
-what `@echecs/game` expects.
+remove `COLOR_MAP`, `TYPE_MAP`, and `PROMOTION_MAP` from `board.stories.tsx`.
+the `toPosition()` helper becomes a direct passthrough since
+`game.position().pieces()` already returns `Map<Square, Piece>` with the right
+types. `PROMOTION_MAP` goes away because `PromotionPiece` values now match what
+`@echecs/game` expects.
 
 ### `orientation` and `turn` props
 
@@ -113,21 +116,21 @@ already use `'black' | 'white'` — no change needed.
 
 ## files affected
 
-| file                              | change                                              |
-|-----------------------------------|-----------------------------------------------------|
-| `src/types.ts`                    | import types from position, update `PromotionPiece`, type `MoveEvent.promotion` |
-| `src/index.ts`                    | re-export `Color`, `File`, `Piece`, `PieceType`, `Rank`, `Square` |
-| `src/fen.ts`                      | update `PIECE_MAP` values                           |
-| `src/board.tsx`                   | add `Piece` → `PieceKey` mapping                    |
-| `src/promotion-dialog.tsx`        | update `PromotionPiece` values, `colorPrefix` mapping |
-| `src/utilities.ts`                | no change (uses `Piece`/`Square` by shape)           |
-| `src/hooks/use-drag.ts`           | no change (uses types by shape)                      |
-| `src/hooks/use-animation.ts`      | no change (uses types by shape)                      |
-| `src/__stories__/board.stories.tsx`| remove conversion helpers                           |
-| `src/__tests__/fen.spec.ts`       | update expected `Piece` values in assertions         |
-| `src/__tests__/board.spec.tsx`    | update any `Piece` literals in test data             |
-| `src/__tests__/promotion-dialog.spec.tsx` | update expected `PromotionPiece` values      |
-| `package.json`                    | add `@echecs/position` to peerDependencies           |
+| file                                      | change                                                                          |
+| ----------------------------------------- | ------------------------------------------------------------------------------- |
+| `src/types.ts`                            | import types from position, update `PromotionPiece`, type `MoveEvent.promotion` |
+| `src/index.ts`                            | re-export `Color`, `File`, `Piece`, `PieceType`, `Rank`, `Square`               |
+| `src/fen.ts`                              | update `PIECE_MAP` values                                                       |
+| `src/board.tsx`                           | add `Piece` → `PieceKey` mapping                                                |
+| `src/promotion-dialog.tsx`                | update `PromotionPiece` values, `colorPrefix` mapping                           |
+| `src/utilities.ts`                        | no change (uses `Piece`/`Square` by shape)                                      |
+| `src/hooks/use-drag.ts`                   | no change (uses types by shape)                                                 |
+| `src/hooks/use-animation.ts`              | no change (uses types by shape)                                                 |
+| `src/__stories__/board.stories.tsx`       | remove conversion helpers                                                       |
+| `src/__tests__/fen.spec.ts`               | update expected `Piece` values in assertions                                    |
+| `src/__tests__/board.spec.tsx`            | update any `Piece` literals in test data                                        |
+| `src/__tests__/promotion-dialog.spec.tsx` | update expected `PromotionPiece` values                                         |
+| `package.json`                            | add `@echecs/position` to peerDependencies                                      |
 
 ## what does NOT change
 
@@ -143,11 +146,14 @@ already use `'black' | 'white'` — no change needed.
 ## breaking change surface
 
 consumers must update if they:
+
 1. pass `Map<Square, Piece>` to the `position` prop — piece values change
 2. handle `PromotionPiece` from `PromotionDialog.onSelect` — values change
-3. read `MoveEvent.promotion` — now typed as `PromotionPiece` instead of `string`
+3. read `MoveEvent.promotion` — now typed as `PromotionPiece` instead of
+   `string`
 
 consumers are unaffected if they:
+
 - use FEN strings for position
 - pass custom `PieceSet` (keys unchanged)
 - only use `onMove`, `onSquareClick` callbacks with `Square` values

--- a/package.json
+++ b/package.json
@@ -51,10 +51,12 @@
     "node": ">=20"
   },
   "peerDependencies": {
+    "@echecs/position": ">=3",
     "react": ">=18"
   },
   "devDependencies": {
     "@echecs/game": "^2.0.0",
+    "@echecs/position": "^3.0.5",
     "@eslint/js": "^10.0.1",
     "@storybook/addon-docs": "^10.3.5",
     "@storybook/react-vite": "^10.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@echecs/game':
         specifier: ^2.0.0
         version: 2.0.2
+      '@echecs/position':
+        specifier: ^3.0.5
+        version: 3.0.5
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.1)

--- a/src/__stories__/board.stories.tsx
+++ b/src/__stories__/board.stories.tsx
@@ -233,34 +233,8 @@ export const CustomArrowColors: Story = {
 
 // -- Interactive: playable game with @echecs/game ---
 
-const COLOR_MAP: Record<string, 'b' | 'w'> = { black: 'b', white: 'w' };
-const PROMOTION_MAP: Record<string, string> = {
-  b: 'bishop',
-  n: 'knight',
-  q: 'queen',
-  r: 'rook',
-};
-const TYPE_MAP: Record<string, 'b' | 'k' | 'n' | 'p' | 'q' | 'r'> = {
-  bishop: 'b',
-  king: 'k',
-  knight: 'n',
-  pawn: 'p',
-  queen: 'q',
-  rook: 'r',
-};
-
 function toPosition(game: Game): Map<Square, Piece> {
-  const result = new Map<Square, Piece>();
-  for (const [square, piece] of game.position().pieces()) {
-    result.set(
-      square as Square,
-      {
-        color: COLOR_MAP[piece.color],
-        type: TYPE_MAP[piece.type],
-      } as Piece,
-    );
-  }
-  return result;
+  return game.position().pieces() as Map<Square, Piece>;
 }
 
 function toLegalMoves(game: Game): Map<Square, Square[]> {
@@ -354,10 +328,9 @@ function InteractiveGame(): React.JSX.Element {
     (piece: string) => {
       if (!pendingPromotion) return;
       try {
-        const promotionType = PROMOTION_MAP[piece] ?? 'queen';
         gameReference.current.move({
           from: pendingPromotion.from,
-          promotion: promotionType as never,
+          promotion: piece as never,
           to: pendingPromotion.to,
         });
         playSound(pendingPromotion, false);

--- a/src/__tests__/fen.spec.ts
+++ b/src/__tests__/fen.spec.ts
@@ -16,20 +16,20 @@ describe('parseFen', () => {
 
     it('has white king on e1', () => {
       const pos = parseFen(STARTING_FEN);
-      expect(pos.get('e1')).toEqual({ color: 'w', type: 'k' });
+      expect(pos.get('e1')).toEqual({ color: 'white', type: 'king' });
     });
 
     it('has black king on e8', () => {
       const pos = parseFen(STARTING_FEN);
-      expect(pos.get('e8')).toEqual({ color: 'b', type: 'k' });
+      expect(pos.get('e8')).toEqual({ color: 'black', type: 'king' });
     });
 
     it('has white pawns on rank 2', () => {
       const pos = parseFen(STARTING_FEN);
       for (const file of ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']) {
         expect(pos.get(`${file}2` as Parameters<typeof pos.get>[0])).toEqual({
-          color: 'w',
-          type: 'p',
+          color: 'white',
+          type: 'pawn',
         });
       }
     });
@@ -38,8 +38,8 @@ describe('parseFen', () => {
       const pos = parseFen(STARTING_FEN);
       for (const file of ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']) {
         expect(pos.get(`${file}7` as Parameters<typeof pos.get>[0])).toEqual({
-          color: 'b',
-          type: 'p',
+          color: 'black',
+          type: 'pawn',
         });
       }
     });
@@ -48,7 +48,7 @@ describe('parseFen', () => {
   describe('after 1.e4', () => {
     it('has pawn on e4', () => {
       const pos = parseFen(AFTER_E4_FEN);
-      expect(pos.get('e4')).toEqual({ color: 'w', type: 'p' });
+      expect(pos.get('e4')).toEqual({ color: 'white', type: 'pawn' });
     });
 
     it('has empty e2', () => {

--- a/src/__tests__/promotion-dialog.spec.tsx
+++ b/src/__tests__/promotion-dialog.spec.tsx
@@ -23,10 +23,10 @@ describe('PromotionDialog', () => {
     const pieces = container.querySelectorAll<HTMLElement>(
       '[data-promotion-piece]',
     );
-    expect(pieces[0]?.dataset.promotionPiece).toBe('q');
-    expect(pieces[1]?.dataset.promotionPiece).toBe('r');
-    expect(pieces[2]?.dataset.promotionPiece).toBe('b');
-    expect(pieces[3]?.dataset.promotionPiece).toBe('n');
+    expect(pieces[0]?.dataset.promotionPiece).toBe('queen');
+    expect(pieces[1]?.dataset.promotionPiece).toBe('rook');
+    expect(pieces[2]?.dataset.promotionPiece).toBe('bishop');
+    expect(pieces[3]?.dataset.promotionPiece).toBe('knight');
   });
 
   it('calls onSelect with the clicked piece', () => {
@@ -35,10 +35,10 @@ describe('PromotionDialog', () => {
       <PromotionDialog color="white" onSelect={onSelect} squareSize={60} />,
     );
     const rook = container.querySelector(
-      '[data-promotion-piece="r"]',
+      '[data-promotion-piece="rook"]',
     ) as HTMLElement;
     fireEvent.click(rook);
-    expect(onSelect).toHaveBeenCalledWith('r');
+    expect(onSelect).toHaveBeenCalledWith('rook');
   });
 
   it('calls onCancel when cancel button is clicked', () => {

--- a/src/__tests__/use-animation.spec.ts
+++ b/src/__tests__/use-animation.spec.ts
@@ -10,8 +10,8 @@ function makePosition(entries: [Square, Piece][]): Map<Square, Piece> {
   return new Map(entries);
 }
 
-const whitePawn: Piece = { color: 'w', type: 'p' };
-const whiteKing: Piece = { color: 'w', type: 'k' };
+const whitePawn: Piece = { color: 'white', type: 'pawn' };
+const whiteKing: Piece = { color: 'white', type: 'king' };
 
 // Stub refs for tests — no board element, no drop info
 const boardReference =

--- a/src/__tests__/utilities.spec.ts
+++ b/src/__tests__/utilities.spec.ts
@@ -93,9 +93,9 @@ describe('squareColor', () => {
 });
 
 describe('diffPositions', () => {
-  const wP: Piece = { color: 'w', type: 'p' };
-  const bP: Piece = { color: 'b', type: 'p' };
-  const wK: Piece = { color: 'w', type: 'k' };
+  const wP: Piece = { color: 'white', type: 'pawn' };
+  const bP: Piece = { color: 'black', type: 'pawn' };
+  const wK: Piece = { color: 'white', type: 'king' };
 
   it('returns empty array for identical positions', () => {
     const pos = new Map<Square, Piece>([['e2', wP]]);

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -8,8 +8,8 @@ import { useDrawing } from './hooks/use-drawing.js';
 import { DEFAULT_PIECES } from './pieces/index.js';
 import { SQUARES, squareColor, squareCoords } from './utilities.js';
 
-import type { Color, PieceType } from '@echecs/position';
 import type { BoardProps as BoardProperties, PieceKey } from './types.js';
+import type { Color, PieceType } from '@echecs/position';
 import type React from 'react';
 
 const STARTING_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -8,10 +8,25 @@ import { useDrawing } from './hooks/use-drawing.js';
 import { DEFAULT_PIECES } from './pieces/index.js';
 import { SQUARES, squareColor, squareCoords } from './utilities.js';
 
+import type { Color, PieceType } from '@echecs/position';
 import type { BoardProps as BoardProperties, PieceKey } from './types.js';
 import type React from 'react';
 
 const STARTING_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+
+const COLOR_PREFIX: Record<Color, 'b' | 'w'> = { black: 'b', white: 'w' };
+const TYPE_SUFFIX: Record<PieceType, string> = {
+  bishop: 'B',
+  king: 'K',
+  knight: 'N',
+  pawn: 'P',
+  queen: 'Q',
+  rook: 'R',
+};
+
+function pieceKey(color: Color, type: PieceType): PieceKey {
+  return `${COLOR_PREFIX[color]}${TYPE_SUFFIX[type]}` as PieceKey;
+}
 
 function Board({
   animate = true,
@@ -165,8 +180,7 @@ function Board({
     const ghostPiece = positionMap.get(dragState.from);
 
     if (ghostPiece) {
-      const ghostKey: PieceKey =
-        `${ghostPiece.color}${ghostPiece.type.toUpperCase()}` as PieceKey;
+      const ghostKey = pieceKey(ghostPiece.color, ghostPiece.type);
       ghostImage = pieces[ghostKey];
     }
   }
@@ -307,8 +321,7 @@ function Board({
           let pieceImage: string | undefined;
 
           if (piece && !hidePiece) {
-            const key: PieceKey =
-              `${piece.color}${piece.type.toUpperCase()}` as PieceKey;
+            const key = pieceKey(piece.color, piece.type);
             pieceImage = pieces[key];
           }
 

--- a/src/fen.ts
+++ b/src/fen.ts
@@ -3,18 +3,18 @@ import type { Piece, Square } from './types.js';
 const FILE_CHARS = 'abcdefgh';
 
 const PIECE_MAP: Record<string, Piece> = {
-  B: { color: 'w', type: 'b' },
-  K: { color: 'w', type: 'k' },
-  N: { color: 'w', type: 'n' },
-  P: { color: 'w', type: 'p' },
-  Q: { color: 'w', type: 'q' },
-  R: { color: 'w', type: 'r' },
-  b: { color: 'b', type: 'b' },
-  k: { color: 'b', type: 'k' },
-  n: { color: 'b', type: 'n' },
-  p: { color: 'b', type: 'p' },
-  q: { color: 'b', type: 'q' },
-  r: { color: 'b', type: 'r' },
+  B: { color: 'white', type: 'bishop' },
+  K: { color: 'white', type: 'king' },
+  N: { color: 'white', type: 'knight' },
+  P: { color: 'white', type: 'pawn' },
+  Q: { color: 'white', type: 'queen' },
+  R: { color: 'white', type: 'rook' },
+  b: { color: 'black', type: 'bishop' },
+  k: { color: 'black', type: 'king' },
+  n: { color: 'black', type: 'knight' },
+  p: { color: 'black', type: 'pawn' },
+  q: { color: 'black', type: 'queen' },
+  r: { color: 'black', type: 'rook' },
 };
 
 /**

--- a/src/hooks/use-drag.ts
+++ b/src/hooks/use-drag.ts
@@ -238,10 +238,7 @@ function useDrag({
           // Clicked another piece → re-select (if correct turn)
           const reselectedPiece = pieces.get(downSquare);
 
-          if (
-            reselectedPiece &&
-            (!turn || reselectedPiece.color === turn)
-          ) {
+          if (reselectedPiece && (!turn || reselectedPiece.color === turn)) {
             setSelectedSquare(downSquare);
 
             return;
@@ -253,10 +250,7 @@ function useDrag({
           // No selection yet: select if there's a piece here (and correct turn)
           const clickedPiece = pieces.get(downSquare);
 
-          if (
-            clickedPiece &&
-            (!turn || clickedPiece.color === turn)
-          ) {
+          if (clickedPiece && (!turn || clickedPiece.color === turn)) {
             setSelectedSquare(downSquare);
           }
         }

--- a/src/hooks/use-drag.ts
+++ b/src/hooks/use-drag.ts
@@ -63,8 +63,6 @@ function useDrag({
   squareSize,
   turn,
 }: UseDragOptions): UseDragResult {
-  const turnColor = turn === 'white' ? 'w' : turn === 'black' ? 'b' : undefined;
-
   const [dragState, setDragState] = useState<DragState>({
     floating: undefined,
     from: undefined,
@@ -154,7 +152,7 @@ function useDrag({
 
       // Only start a drag if there's a piece on the source square
       // and it matches the turn color (when turn is set)
-      if (piece && (!turnColor || piece.color === turnColor)) {
+      if (piece && (!turn || piece.color === turn)) {
         setDragState({ floating: undefined, from: square, isDragging: false });
       }
     },
@@ -165,7 +163,7 @@ function useDrag({
       orientation,
       pieces,
       squareSize,
-      turnColor,
+      turn,
     ],
   );
 
@@ -242,7 +240,7 @@ function useDrag({
 
           if (
             reselectedPiece &&
-            (!turnColor || reselectedPiece.color === turnColor)
+            (!turn || reselectedPiece.color === turn)
           ) {
             setSelectedSquare(downSquare);
 
@@ -257,7 +255,7 @@ function useDrag({
 
           if (
             clickedPiece &&
-            (!turnColor || clickedPiece.color === turnColor)
+            (!turn || clickedPiece.color === turn)
           ) {
             setSelectedSquare(downSquare);
           }
@@ -280,7 +278,7 @@ function useDrag({
           toSquare &&
           toSquare !== downSquare &&
           draggedPiece &&
-          (!turnColor || draggedPiece.color === turnColor) &&
+          (!turn || draggedPiece.color === turn) &&
           isLegalTarget(downSquare, toSquare)
         ) {
           dropReference.current = {
@@ -303,7 +301,7 @@ function useDrag({
       pieces,
       selectedSquare,
       squareSize,
-      turnColor,
+      turn,
     ],
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,13 +9,17 @@ export type {
   ArrowKind,
   BoardProps,
   Circle,
+  Color,
+  File,
   MoveEvent,
+  Piece,
   PieceKey,
   PieceSet,
+  PieceType,
+  PromotionPiece,
+  Rank,
+  Square,
 } from './types.js';
 
-export type {
-  PromotionDialogProps,
-  PromotionPiece,
-} from './promotion-dialog.js';
+export type { PromotionDialogProps } from './promotion-dialog.js';
 export type { SquareCoords } from './utilities.js';

--- a/src/promotion-dialog.tsx
+++ b/src/promotion-dialog.tsx
@@ -1,9 +1,8 @@
 import { DEFAULT_PIECES } from './pieces/index.js';
 
-import type { PieceKey, PieceSet } from './types.js';
+import type { PieceKey, PieceSet, PromotionPiece } from './types.js';
+import type { Color } from '@echecs/position';
 import type React from 'react';
-
-type PromotionPiece = 'b' | 'n' | 'q' | 'r';
 
 interface PromotionDialogProperties {
   color: 'black' | 'white';
@@ -13,7 +12,15 @@ interface PromotionDialogProperties {
   squareSize: number;
 }
 
-const PROMOTION_PIECES: PromotionPiece[] = ['q', 'r', 'b', 'n'];
+const PROMOTION_PIECES: PromotionPiece[] = ['queen', 'rook', 'bishop', 'knight'];
+
+const COLOR_PREFIX: Record<Color, 'b' | 'w'> = { black: 'b', white: 'w' };
+const TYPE_KEY: Record<PromotionPiece, string> = {
+  bishop: 'B',
+  knight: 'N',
+  queen: 'Q',
+  rook: 'R',
+};
 
 function PromotionDialog({
   color,
@@ -22,7 +29,7 @@ function PromotionDialog({
   pieces = DEFAULT_PIECES,
   squareSize,
 }: PromotionDialogProperties): React.JSX.Element {
-  const colorPrefix = color === 'white' ? 'w' : 'b';
+  const colorPrefix = COLOR_PREFIX[color];
 
   const containerStyle: React.CSSProperties = {
     display: 'flex',
@@ -45,7 +52,7 @@ function PromotionDialog({
     <div data-promotion-dialog style={containerStyle}>
       {PROMOTION_PIECES.map((piece) => {
         const key: PieceKey =
-          `${colorPrefix}${piece.toUpperCase()}` as PieceKey;
+          `${colorPrefix}${TYPE_KEY[piece]}` as PieceKey;
         const pieceImage = pieces[key];
 
         return (
@@ -92,7 +99,4 @@ function PromotionDialog({
 }
 
 export { PromotionDialog };
-export type {
-  PromotionDialogProperties as PromotionDialogProps,
-  PromotionPiece,
-};
+export type { PromotionDialogProperties as PromotionDialogProps };

--- a/src/promotion-dialog.tsx
+++ b/src/promotion-dialog.tsx
@@ -12,7 +12,12 @@ interface PromotionDialogProperties {
   squareSize: number;
 }
 
-const PROMOTION_PIECES: PromotionPiece[] = ['queen', 'rook', 'bishop', 'knight'];
+const PROMOTION_PIECES: PromotionPiece[] = [
+  'queen',
+  'rook',
+  'bishop',
+  'knight',
+];
 
 const COLOR_PREFIX: Record<Color, 'b' | 'w'> = { black: 'b', white: 'w' };
 const TYPE_KEY: Record<PromotionPiece, string> = {
@@ -51,8 +56,7 @@ function PromotionDialog({
   return (
     <div data-promotion-dialog style={containerStyle}>
       {PROMOTION_PIECES.map((piece) => {
-        const key: PieceKey =
-          `${colorPrefix}${TYPE_KEY[piece]}` as PieceKey;
+        const key: PieceKey = `${colorPrefix}${TYPE_KEY[piece]}` as PieceKey;
         const pieceImage = pieces[key];
 
         return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,26 +1,7 @@
+import type { Color, File, Piece, PieceType, Rank, Square } from '@echecs/position';
 import type React from 'react';
 
 type ArrowKind = 'alternative' | 'capture' | 'danger' | 'move';
-
-type Color = 'b' | 'w';
-
-type File = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h';
-
-type PieceType = 'b' | 'k' | 'n' | 'p' | 'q' | 'r';
-
-type Rank = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8';
-
-/**
- * A board square, e.g. `'e4'`. Combination of {@link File} and {@link Rank}.
- *
- * @preventExpand
- */
-type Square = `${File}${Rank}`;
-
-interface Piece {
-  color: Color;
-  type: PieceType;
-}
 
 interface Annotations {
   arrows: Arrow[];
@@ -73,10 +54,12 @@ interface Circle {
   square: Square;
 }
 
+type PromotionPiece = Exclude<PieceType, 'king' | 'pawn'>;
+
 interface MoveEvent {
   capture: boolean;
   from: Square;
-  promotion?: string;
+  promotion?: PromotionPiece;
   to: Square;
 }
 
@@ -102,9 +85,14 @@ export type {
   ArrowKind,
   BoardProperties as BoardProps,
   Circle,
+  Color,
+  File,
   MoveEvent,
   Piece,
   PieceKey,
   PieceSet,
+  PieceType,
+  PromotionPiece,
+  Rank,
   Square,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Color, File, Piece, PieceType, Rank, Square } from '@echecs/position';
+import type { Piece, PieceType, Square } from '@echecs/position';
 import type React from 'react';
 
 type ArrowKind = 'alternative' | 'capture' | 'danger' | 'move';
@@ -85,14 +85,10 @@ export type {
   ArrowKind,
   BoardProperties as BoardProps,
   Circle,
-  Color,
-  File,
   MoveEvent,
-  Piece,
   PieceKey,
   PieceSet,
-  PieceType,
   PromotionPiece,
-  Rank,
-  Square,
 };
+
+export type { Color, File, Piece, PieceType, Rank, Square } from '@echecs/position';

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,4 +91,11 @@ export type {
   PromotionPiece,
 };
 
-export type { Color, File, Piece, PieceType, Rank, Square } from '@echecs/position';
+export type {
+  Color,
+  File,
+  Piece,
+  PieceType,
+  Rank,
+  Square,
+} from '@echecs/position';


### PR DESCRIPTION
## Summary

closes #57

- imports `Color`, `File`, `Piece`, `PieceType`, `Rank`, `Square` from `@echecs/position` instead of defining them locally
- `Color` is now `'black' | 'white'` (was `'b' | 'w'`)
- `PieceType` is now `'bishop' | 'king' | 'knight' | 'pawn' | 'queen' | 'rook'` (was `'b' | 'k' | 'n' | 'p' | 'q' | 'r'`)
- `PromotionPiece` is now `'bishop' | 'knight' | 'queen' | 'rook'` (was `'b' | 'n' | 'q' | 'r'`)
- `MoveEvent.promotion` is typed as `PromotionPiece` (was `string`)
- `@echecs/position` added as peer dependency (`>=3`)
- `PieceKey` and `PieceSet` unchanged — rendering concern, not domain

## breaking changes

consumers must update if they:
- pass `Map<Square, Piece>` to the `position` prop
- handle `PromotionPiece` from `PromotionDialog.onSelect`
- read `MoveEvent.promotion`

consumers using FEN strings or custom `PieceSet` are unaffected.