### PR TITLE
release: @echecs/react-board@3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [3.0.0] - 2026-05-01
+
+### Changed
+
+- **BREAKING:** `Color` type is now `'black' | 'white'` (was `'b' | 'w'`)
+- **BREAKING:** `PieceType` type is now
+  `'bishop' | 'king' | 'knight' | 'pawn' | 'queen' | 'rook'` (was
+  `'b' | 'k' | 'n' | 'p' | 'q' | 'r'`)
+- **BREAKING:** `PromotionPiece` type is now
+  `'bishop' | 'knight' | 'queen' | 'rook'` (was `'b' | 'n' | 'q' | 'r'`)
+- **BREAKING:** `MoveEvent.promotion` is now typed as `PromotionPiece` (was
+  `string`)
+- `Color`, `File`, `Piece`, `PieceType`, `Rank`, `Square` are now imported from
+  `@echecs/position` and re-exported — consumers can pass
+  `game.position().pieces()` directly to the `position` prop without conversion
+
+### Added
+
+- `@echecs/position` (`>=3`) as a peer dependency
+- `Color`, `File`, `PieceType`, `Rank` added to public type exports
+
 ## [2.1.3] - 2026-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install @echecs/react-board
 pnpm add @echecs/react-board
 ```
 
-React ≥18 is a peer dependency.
+Peer dependencies: React ≥18, `@echecs/position` ≥3.
 
 ## Quick start
 
@@ -163,7 +163,7 @@ import { PromotionDialog } from '@echecs/react-board';
 <PromotionDialog
   color="white"
   squareSize={60}
-  onSelect={(piece) => console.log(piece)} // 'q' | 'r' | 'b' | 'n'
+  onSelect={(piece) => console.log(piece)} // 'queen' | 'rook' | 'bishop' | 'knight'
   onCancel={() => console.log('cancelled')}
 />;
 ```
@@ -194,19 +194,25 @@ squareCoords('e4', 'black'); // { col: 4, row: 4 }
 
 ### Exported types
 
-| Type                   | Description                                                            |
-| ---------------------- | ---------------------------------------------------------------------- |
-| `Annotations`          | `{ arrows: Arrow[]; circles: Circle[] }` — drawable annotation state   |
-| `Arrow`                | `{ from: Square; to: Square; kind: ArrowKind }` — arrow descriptor     |
-| `ArrowKind`            | `'alternative' \| 'capture' \| 'danger' \| 'move'` — annotation colour |
-| `BoardProps`           | All props accepted by `<Board />`                                      |
-| `Circle`               | `{ square: Square; kind: ArrowKind }` — circle annotation descriptor   |
-| `MoveEvent`            | `{ from, to, capture, promotion? }` — passed to `onMove`               |
-| `PieceKey`             | Union of all 12 piece keys (`'wK'`, `'bP'`, …)                         |
-| `PieceSet`             | `Record<PieceKey, string>` — maps piece keys to image URLs             |
-| `PromotionDialogProps` | All props accepted by `<PromotionDialog />`                            |
-| `PromotionPiece`       | `'q' \| 'r' \| 'b' \| 'n'` — promotable piece                          |
-| `SquareCoords`         | `{ col: number; row: number }` — return type of `squareCoords`         |
+| Type                   | Description                                                                |
+| ---------------------- | -------------------------------------------------------------------------- |
+| `Annotations`          | `{ arrows: Arrow[]; circles: Circle[] }` — drawable annotation state       |
+| `Arrow`                | `{ from: Square; to: Square; kind: ArrowKind }` — arrow descriptor         |
+| `ArrowKind`            | `'alternative' \| 'capture' \| 'danger' \| 'move'` — annotation colour     |
+| `BoardProps`           | All props accepted by `<Board />`                                          |
+| `Circle`               | `{ square: Square; kind: ArrowKind }` — circle annotation descriptor       |
+| `Color`                | `'black' \| 'white'` — piece colour (from `@echecs/position`)              |
+| `File`                 | `'a' \| 'b' \| … \| 'h'` — board file (from `@echecs/position`)            |
+| `MoveEvent`            | `{ from, to, capture, promotion? }` — passed to `onMove`                   |
+| `Piece`                | `{ color: Color; type: PieceType }` — piece on a square                    |
+| `PieceKey`             | Union of all 12 piece keys (`'wK'`, `'bP'`, …)                             |
+| `PieceSet`             | `Record<PieceKey, string>` — maps piece keys to image URLs                 |
+| `PieceType`            | `'bishop' \| 'king' \| … \| 'rook'` — piece type (from `@echecs/position`) |
+| `PromotionDialogProps` | All props accepted by `<PromotionDialog />`                                |
+| `PromotionPiece`       | `'bishop' \| 'knight' \| 'queen' \| 'rook'` — promotable piece             |
+| `Rank`                 | `'1' \| '2' \| … \| '8'` — board rank (from `@echecs/position`)            |
+| `Square`               | `` `${File}${Rank}` `` — board square (from `@echecs/position`)            |
+| `SquareCoords`         | `{ col: number; row: number }` — return type of `squareCoords`             |
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echecs/react-board",
-  "version": "2.1.3",
+  "version": "3.0.0",
   "type": "module",
   "license": "MIT",
   "description": "React chessboard component with drag & drop, animation, and theming. Bundled cburnett piece set, zero external dependencies.",


### PR DESCRIPTION
## Summary

- bumps version to 3.0.0
- updates CHANGELOG.md with breaking changes
- updates README.md with new peer dep, updated type docs, and corrected `PromotionPiece` values