### PR TITLE
chore: remove unnecessary main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "./sounds/game-end.mp3": "./sounds/game-end.mp3",
     "./sounds/move.mp3": "./sounds/move.mp3"
   },
-  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "/dist/",


### PR DESCRIPTION
ESM-only package with exports — main is a CJS-era field that is not needed