### PR TITLE
chore: normalize types field path

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "./sounds/game-end.mp3": "./sounds/game-end.mp3",
     "./sounds/move.mp3": "./sounds/move.mp3"
   },
-  "types": "dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
     "/dist/",
     "/sounds/",


### PR DESCRIPTION
uses relative ./dist/index.d.ts path consistently across all packages