### PR TITLE
chore: bump minimum node to 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "CHANGELOG.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "peerDependencies": {
     "@echecs/position": ">=3",


### PR DESCRIPTION
node 20 reached EOL on april 30 2026 — 22 is the oldest maintained LTS