### PR TITLE
chore: add .storybook/ to eslint ignores

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import unicorn from 'eslint-plugin-unicorn';
 import * as typescript from 'typescript-eslint';
 
 export default typescript.config(
-  { ignores: ['tsdown.config.ts'] },
+  { ignores: ['.storybook/', 'tsdown.config.ts'] },
   eslint.configs.recommended,
   ...typescript.configs.strict,
   ...typescript.configs.stylistic,


### PR DESCRIPTION
adds `.storybook/` to eslint ignores — consistent with react-movesheet