### PR TITLE
chore: add argsIgnorePattern to no-unused-vars rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -92,6 +92,10 @@ export default typescript.config(
         },
       ],
       '@typescript-eslint/no-non-null-assertion': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_' },
+      ],
     },
     settings: {
       'import-x/resolver': {


### PR DESCRIPTION
adds `argsIgnorePattern: '^_'` to `@typescript-eslint/no-unused-vars` — aligns with buchholz, number-of-wins, progressive, sonneborn-berger